### PR TITLE
[Ticket 9] Add related product controller tests 

### DIFF
--- a/controllers/constants/productConstants.js
+++ b/controllers/constants/productConstants.js
@@ -1,1 +1,2 @@
 export const PRODUCT_LIMIT = 12;
+export const RELATED_PRODUCT_LIMIT = 3;

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -288,6 +288,12 @@ export const searchProductController = async (req, res) => {
 export const relatedProductController = async (req, res) => {
   try {
     const { pid, cid } = req.params;
+    if (!pid || !cid) {
+      return res.status(400).send({
+        success: false,
+        message: "Pid and Cid cannot be null",
+      });
+    }
     const products = await productModel
       .find({
         category: cid,

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -10,6 +10,7 @@ import {
   PRODUCT_LIMIT,
   RELATED_PRODUCT_LIMIT,
 } from "./constants/productConstants.js";
+import mongoose from "mongoose";
 
 dotenv.config();
 
@@ -288,12 +289,20 @@ export const searchProductController = async (req, res) => {
 export const relatedProductController = async (req, res) => {
   try {
     const { pid, cid } = req.params;
-    if (!pid || !cid) {
+
+    // Gives this status error when pid/cid is null or invalid
+    if (
+      !pid ||
+      !cid ||
+      !mongoose.Types.ObjectId.isValid(pid) ||
+      !mongoose.Types.ObjectId.isValid(cid)
+    ) {
       return res.status(400).send({
         success: false,
-        message: "Pid and Cid cannot be null",
+        message: "Pid and Cid must be in a valid format",
       });
     }
+
     const products = await productModel
       .find({
         category: cid,
@@ -302,6 +311,7 @@ export const relatedProductController = async (req, res) => {
       .select("-photo")
       .limit(RELATED_PRODUCT_LIMIT)
       .populate("category");
+
     res.status(200).send({
       success: true,
       products,

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -6,7 +6,10 @@ import fs from "fs";
 import slugify from "slugify";
 import braintree from "braintree";
 import dotenv from "dotenv";
-import { PRODUCT_LIMIT } from "./constants/productConstants.js";
+import {
+  PRODUCT_LIMIT,
+  RELATED_PRODUCT_LIMIT,
+} from "./constants/productConstants.js";
 
 dotenv.config();
 
@@ -282,7 +285,7 @@ export const searchProductController = async (req, res) => {
 };
 
 // similar products
-export const realtedProductController = async (req, res) => {
+export const relatedProductController = async (req, res) => {
   try {
     const { pid, cid } = req.params;
     const products = await productModel
@@ -291,7 +294,7 @@ export const realtedProductController = async (req, res) => {
         _id: { $ne: pid },
       })
       .select("-photo")
-      .limit(3)
+      .limit(RELATED_PRODUCT_LIMIT)
       .populate("category");
     res.status(200).send({
       success: true,

--- a/controllers/tests/getRelatedProductController.test.js
+++ b/controllers/tests/getRelatedProductController.test.js
@@ -102,6 +102,48 @@ describe("Get Related Product Controller tests", () => {
     });
   });
 
+  // add more equivalence classes
+  it("Should return error response when pid is null", async () => {
+    req = { params: { cid: "456" } };
+
+    await relatedProductController(req, res);
+
+    // Assertions
+    expect(res.status).toBeCalledWith(400);
+    expect(res.send).toBeCalledWith({
+      success: false,
+      message: "Pid and Cid cannot be null",
+    });
+  });
+
+  // add more equivalence classes
+  it("Should return error response when cid is null", async () => {
+    req = { params: { pid: "456" } };
+
+    await relatedProductController(req, res);
+
+    // Assertions
+    expect(res.status).toBeCalledWith(400);
+    expect(res.send).toBeCalledWith({
+      success: false,
+      message: "Pid and Cid cannot be null",
+    });
+  });
+
+  // add more equivalence classes
+  it("Should return error response when both cid and pid is null", async () => {
+    req = { params: {} };
+
+    await relatedProductController(req, res);
+
+    // Assertions
+    expect(res.status).toBeCalledWith(400);
+    expect(res.send).toBeCalledWith({
+      success: false,
+      message: "Pid and Cid cannot be null",
+    });
+  });
+
   it("Should return error response when there is error fetching related products", async () => {
     req = { params: { pid: "0", cid: "456" } };
     const mockFindError = {

--- a/controllers/tests/getRelatedProductController.test.js
+++ b/controllers/tests/getRelatedProductController.test.js
@@ -1,6 +1,7 @@
 import { jest } from "@jest/globals";
 import productModel from "../../models/productModel.js";
 import { relatedProductController } from "../productController.js";
+import { ObjectId } from "mongodb";
 
 jest.mock("../../models/productModel");
 describe("Get Related Product Controller tests", () => {
@@ -8,13 +9,13 @@ describe("Get Related Product Controller tests", () => {
 
   const mockProducts = [
     {
-      _id: "123",
+      _id: new ObjectId("51f45420a784984f2942e609"),
       name: "Toy Giraffe",
       slug: "Toy-Giraffe",
       description: "Some toy giraffe",
       price: 10,
       category: {
-        _id: "456",
+        _id: new ObjectId("bc7f29ed898fefd6a5f713fd"),
         name: "Toys",
         slug: "toys",
         __v: 0,
@@ -25,13 +26,13 @@ describe("Get Related Product Controller tests", () => {
       __v: 0,
     },
     {
-      _id: "234",
+      _id: new ObjectId("242ddde9effa794b93f20688"),
       name: "Toy cars",
       slug: "Toy-cars",
       description: "some toy cars",
       price: 15,
       category: {
-        _id: "456",
+        _id: new ObjectId("bc7f29ed898fefd6a5f713fd"),
         name: "Toys",
         slug: "toys",
         __v: 0,
@@ -62,16 +63,35 @@ describe("Get Related Product Controller tests", () => {
     jest.resetModules();
   });
 
-  it("Should fetch related products successfully", async () => {
-    req = { params: { pid: "345", cid: "456" } }; // existent category
+  /**
+   * Pairwise testing
+   * Related products controller takes in 2 inputs, pid and cid.
+   * Each input has 3 equivalence classes,
+   * where a cid or pid can be of:
+   *
+   * 1. Valid form and exists in DB
+   * 2. Valid form but does not exist in DB
+   * 3. Invalid form (naturally will not exist)
+   *
+   * There are a total of 9 pairwise tests below to cover all pairs
+   */
+
+  // Pairwise test 1: valid and existent cid, valid but non-existent pid
+  it("Should fetch related products successfully when valid & existent cid and valid & non-existent pid", async () => {
+    req = {
+      params: {
+        pid: "9379452f970cbbd38ac79478",
+        cid: "bc7f29ed898fefd6a5f713fd",
+      },
+    };
     productModel.find = jest.fn().mockReturnValue(mockFindRelatedProducts);
 
     await relatedProductController(req, res);
 
     // Assertions
     expect(productModel.find).toHaveBeenCalledWith({
-      category: "456",
-      _id: { $ne: "345" },
+      category: "bc7f29ed898fefd6a5f713fd",
+      _id: { $ne: "9379452f970cbbd38ac79478" },
     });
     expect(res.status).toBeCalledWith(200);
     expect(res.send).toBeCalledWith({
@@ -80,8 +100,42 @@ describe("Get Related Product Controller tests", () => {
     });
   });
 
-  it("Should return an empty array if category does not exist", async () => {
-    req = { params: { pid: "123", cid: "999" } }; // Non-existent category
+  // Pairwise test 2:  valid and existent cid, valid and existent pid
+  it("Should fetch related products successfully when valid & existent cid and valid & existent pid", async () => {
+    req = {
+      params: {
+        pid: "242ddde9effa794b93f20688", // same pid as second product in mockProducts
+        cid: "bc7f29ed898fefd6a5f713fd",
+      },
+    };
+
+    mockFindRelatedProducts.populate = jest
+      .fn()
+      .mockResolvedValue(mockProducts.slice(0, 1)); // exclude second product in mockProducts
+    productModel.find = jest.fn().mockReturnValue(mockFindRelatedProducts);
+
+    await relatedProductController(req, res);
+
+    // Assertions
+    expect(productModel.find).toHaveBeenCalledWith({
+      category: "bc7f29ed898fefd6a5f713fd",
+      _id: { $ne: "242ddde9effa794b93f20688" },
+    });
+    expect(res.status).toBeCalledWith(200);
+    expect(res.send).toBeCalledWith({
+      success: true,
+      products: mockProducts.slice(0, 1),
+    });
+  });
+
+  // Pairwise test 3: valid but non-existent cid, valid and existent pid
+  it("Should return an empty array when valid & non-existent cid, valid & existent pid", async () => {
+    req = {
+      params: {
+        pid: "242ddde9effa794b93f20688",
+        cid: "6d619356ed85340ea427b6cc", // Non-existent category
+      },
+    };
     const mockFindNonExistentCategory = {
       ...mockFindRelatedProducts,
       populate: jest.fn().mockResolvedValue([]),
@@ -92,8 +146,8 @@ describe("Get Related Product Controller tests", () => {
     await relatedProductController(req, res);
 
     expect(productModel.find).toHaveBeenCalledWith({
-      category: "999",
-      _id: { $ne: "123" },
+      category: "6d619356ed85340ea427b6cc",
+      _id: { $ne: "242ddde9effa794b93f20688" },
     });
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.send).toHaveBeenCalledWith({
@@ -102,9 +156,9 @@ describe("Get Related Product Controller tests", () => {
     });
   });
 
-  // add more equivalence classes
-  it("Should return error response when pid is null", async () => {
-    req = { params: { cid: "456" } };
+  // Pairwise test 4: valid and existent cid, invalid pid
+  it("Should return error response when valid and existent cid, invalid pid (null)", async () => {
+    req = { params: { cid: "bc7f29ed898fefd6a5f713fd" } };
 
     await relatedProductController(req, res);
 
@@ -112,13 +166,13 @@ describe("Get Related Product Controller tests", () => {
     expect(res.status).toBeCalledWith(400);
     expect(res.send).toBeCalledWith({
       success: false,
-      message: "Pid and Cid cannot be null",
+      message: "Pid and Cid must be in a valid format",
     });
   });
 
-  // add more equivalence classes
-  it("Should return error response when cid is null", async () => {
-    req = { params: { pid: "456" } };
+  // Pairwise test 5: invalid cid, valid and existent pid
+  it("Should return error response when invalid cid, valid & existent pid", async () => {
+    req = { params: { cid: "abc", pid: "242ddde9effa794b93f20688" } }; // cid is invalid as it doesn't conform to correct form
 
     await relatedProductController(req, res);
 
@@ -126,13 +180,41 @@ describe("Get Related Product Controller tests", () => {
     expect(res.status).toBeCalledWith(400);
     expect(res.send).toBeCalledWith({
       success: false,
-      message: "Pid and Cid cannot be null",
+      message: "Pid and Cid must be in a valid format",
     });
   });
 
-  // add more equivalence classes
-  it("Should return error response when both cid and pid is null", async () => {
-    req = { params: {} };
+  // Pairwise test 6 valid but non-existent cid, valid but non-existent pid
+  it("Should return an empty array when valid & non-existent cid, valid & non-existent pid", async () => {
+    req = {
+      params: {
+        pid: "14155289517d158088a0e52c", // Non-existent product
+        cid: "43e63da2506585e3b8768181", // Non-existent category
+      },
+    };
+    const mockFindNonExistent = {
+      ...mockFindRelatedProducts,
+      populate: jest.fn().mockResolvedValue([]),
+    };
+
+    productModel.find = jest.fn().mockReturnValue(mockFindNonExistent);
+
+    await relatedProductController(req, res);
+
+    expect(productModel.find).toHaveBeenCalledWith({
+      category: "43e63da2506585e3b8768181",
+      _id: { $ne: "14155289517d158088a0e52c" },
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith({
+      success: true,
+      products: [],
+    });
+  });
+
+  // Pairwise test 7: invalid cid, valid but non-existent pid
+  it("Should return error response when invalid cid, valid & non-existent pid", async () => {
+    req = { params: { pid: "14155289517d158088a0e52cs" } }; // cid is invalid as it is null
 
     await relatedProductController(req, res);
 
@@ -140,12 +222,45 @@ describe("Get Related Product Controller tests", () => {
     expect(res.status).toBeCalledWith(400);
     expect(res.send).toBeCalledWith({
       success: false,
-      message: "Pid and Cid cannot be null",
+      message: "Pid and Cid must be in a valid format",
+    });
+  });
+
+  // Pairwise test 8: valid but non-existent cid, invalid pid
+  it("Should return error response when valid & non-existent cid, invalid pid", async () => {
+    req = { params: { cid: "43e63da2506585e3b8768181", pid: "123" } }; // pid is invalid as it doesn't conform to Mongo ObjectId form
+
+    await relatedProductController(req, res);
+
+    // Assertions
+    expect(res.status).toBeCalledWith(400);
+    expect(res.send).toBeCalledWith({
+      success: false,
+      message: "Pid and Cid must be in a valid format",
+    });
+  });
+
+  // Pairwise test 9: invalid cid, invalid pid
+  it("Should return error response when invalid cid and invalid pid", async () => {
+    req = { params: {} }; // both cid and pid are invalid as they are both null
+
+    await relatedProductController(req, res);
+
+    // Assertions
+    expect(res.status).toBeCalledWith(400);
+    expect(res.send).toBeCalledWith({
+      success: false,
+      message: "Pid and Cid must be in a valid format",
     });
   });
 
   it("Should return error response when there is error fetching related products", async () => {
-    req = { params: { pid: "0", cid: "456" } };
+    req = {
+      params: {
+        pid: "9379452f970cbbd38ac79478",
+        cid: "bc7f29ed898fefd6a5f713fd",
+      },
+    };
     const mockFindError = {
       ...mockFindRelatedProducts,
       populate: jest.fn().mockImplementation(() => {

--- a/controllers/tests/getRelatedProductController.test.js
+++ b/controllers/tests/getRelatedProductController.test.js
@@ -1,0 +1,126 @@
+import { jest } from "@jest/globals";
+import productModel from "../../models/productModel.js";
+import { relatedProductController } from "../productController.js";
+
+jest.mock("../../models/productModel");
+describe("Get Related Product Controller tests", () => {
+  let res, req, mockFindRelatedProducts;
+
+  const mockProducts = [
+    {
+      _id: "123",
+      name: "Toy Giraffe",
+      slug: "Toy-Giraffe",
+      description: "Some toy giraffe",
+      price: 10,
+      category: {
+        _id: "456",
+        name: "Toys",
+        slug: "toys",
+        __v: 0,
+      },
+      quantity: 12,
+      createdAt: "2025-02-02T10:19:37.524Z",
+      updatedAt: "2025-02-13T08:11:52.724Z",
+      __v: 0,
+    },
+    {
+      _id: "234",
+      name: "Toy cars",
+      slug: "Toy-cars",
+      description: "some toy cars",
+      price: 15,
+      category: {
+        _id: "456",
+        name: "Toys",
+        slug: "toys",
+        __v: 0,
+      },
+      quantity: 1,
+      createdAt: "2025-02-02T10:19:37.524Z",
+      updatedAt: "2025-02-13T08:11:52.724Z",
+      __v: 0,
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    };
+
+    mockFindRelatedProducts = {
+      select: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      populate: jest.fn().mockResolvedValue(mockProducts),
+    };
+  });
+
+  beforeAll(() => {
+    jest.resetModules();
+  });
+
+  it("Should fetch related products successfully", async () => {
+    req = { params: { pid: "345", cid: "456" } }; // existent category
+    productModel.find = jest.fn().mockReturnValue(mockFindRelatedProducts);
+
+    await relatedProductController(req, res);
+
+    // Assertions
+    expect(productModel.find).toHaveBeenCalledWith({
+      category: "456",
+      _id: { $ne: "345" },
+    });
+    expect(res.status).toBeCalledWith(200);
+    expect(res.send).toBeCalledWith({
+      success: true,
+      products: mockProducts,
+    });
+  });
+
+  it("Should return an empty array if category does not exist", async () => {
+    req = { params: { pid: "123", cid: "999" } }; // Non-existent category
+    const mockFindNonExistentCategory = {
+      ...mockFindRelatedProducts,
+      populate: jest.fn().mockResolvedValue([]),
+    };
+
+    productModel.find = jest.fn().mockReturnValue(mockFindNonExistentCategory);
+
+    await relatedProductController(req, res);
+
+    expect(productModel.find).toHaveBeenCalledWith({
+      category: "999",
+      _id: { $ne: "123" },
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith({
+      success: true,
+      products: [],
+    });
+  });
+
+  it("Should return error response when there is error fetching related products", async () => {
+    req = { params: { pid: "0", cid: "456" } };
+    const mockFindError = {
+      ...mockFindRelatedProducts,
+      populate: jest.fn().mockImplementation(() => {
+        throw new Error("some error");
+      }),
+    };
+
+    productModel.find = jest.fn().mockReturnValue(mockFindError);
+
+    await relatedProductController(req, res);
+
+    // Assertions
+    expect(res.status).toBeCalledWith(400);
+    expect(res.send).toBeCalledWith({
+      success: false,
+      message: "error while geting related product",
+      error: new Error("some error"),
+    });
+  });
+});

--- a/routes/productRoutes.js
+++ b/routes/productRoutes.js
@@ -11,7 +11,7 @@ import {
   productFiltersController,
   productListController,
   productPhotoController,
-  realtedProductController,
+  relatedProductController,
   searchProductController,
   updateProductController,
 } from "../controllers/productController.js";
@@ -62,7 +62,7 @@ router.get("/product-list/:page", productListController);
 router.get("/search/:keyword", searchProductController);
 
 //similar product
-router.get("/related-product/:pid/:cid", realtedProductController);
+router.get("/related-product/:pid/:cid", relatedProductController);
 
 //category wise product
 router.get("/product-category/:slug", productCategoryController);


### PR DESCRIPTION
Scenarios covered:
1. Fetch related products successfully with existent cid
2. Fetch no related products wihen non-existent cid
3. Return error response when there is error fetching related products