### PR TITLE
Added forget password controller and update profile controller tests

### DIFF
--- a/client/src/pages/user/Profile.js
+++ b/client/src/pages/user/Profile.js
@@ -34,7 +34,7 @@ const Profile = () => {
         phone,
         address,
       });
-      if (data?.errro) {
+      if (data?.error) {
         toast.error(data?.error);
       } else {
         setAuth({ ...auth, user: data?.updatedUser });
@@ -45,8 +45,12 @@ const Profile = () => {
         toast.success("Profile Updated Successfully");
       }
     } catch (error) {
-      console.log(error);
-      toast.error("Something went wrong");
+      if (error.response && error.response.status === 400) {
+        toast.error(error.response?.data?.message);
+      } else {
+        console.log(error);
+        toast.error("Something went wrong");
+      }
     }
   };
   return (

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -9,7 +9,7 @@ export const registerController = async (req, res) => {
     const { name, email, password, phone, address, answer } = req.body;
     //validations
     if (!name) {
-      return res.send({ error: "Name is Required" });
+      return res.send({ message: "Name is Required" });
     }
     if (!email) {
       return res.send({ message: "Email is Required" });
@@ -27,9 +27,14 @@ export const registerController = async (req, res) => {
       return res.send({ message: "Answer is Required" });
     }
 
+    // Add validation for name (Maximum 150 characters long)
+    if (name.length > 150) {
+      return res.status(400).send({ message: "The name can only be up to 150 characters long"});
+    }
+
     // Add validation for password length (Need to be minimum of length 6)
     if (password.length < 6) {
-      return res.status(404).send({ message: "The length of the password should be at least 6 characters long"});
+      return res.status(400).send({ message: "The length of the password should be at least 6 characters long"});
     }
 
     // Add validation for email check 
@@ -38,21 +43,36 @@ export const registerController = async (req, res) => {
     1) Cannot start with dot
     2) Cannot have consecutive dots
     3) Cannot end with dot
-    4) Restrict characters to alphanumeric, underscore and dot
+    4) Restrict characters to alphanumeric and dot
     5) Maximally is 64 characters long
     
     Domain part
     1) Cannot start with dot
     2) Cannot have consecutive dots
     3) Cannot end with dot
-    4) Cannot start with underscore
-    5) Restrict characters to alphanumeric and dot
-    6) Maximally is 64 characters long
+    4) Restrict characters to alphanumeric and dot
+    5) Maximally is 64 characters long
     
     */
-    const emailRegex = /^(?!^\.)(?!.*\.@)(?!.*\.{2})[a-zA-Z0-9_.]{1,64}@(?!@\.)(?!.*\.$)(?!.*\.{2})[a-zA-Z0-9.]{1,64}$/    
+    const emailRegex = /^(?!^\.)(?!.*\.@)(?!.*\.{2})[a-zA-Z0-9.]{1,64}@(?!@\.)(?!.*\.$)(?!.*\.{2})[a-zA-Z0-9.]{1,64}$/;    
     if (!email.match(emailRegex)) {
-      return res.status(404).send({ message: "The email is in an invalid format"});
+      return res.status(400).send({ message: "The email is in an invalid format"});
+    }
+
+    // Add validation for phone number
+    const phoneRegex = /^[689]\d{7}$/;
+    if (!phone.match(phoneRegex)) {
+      return res.status(400).send({ message: "The phone number must start with 6,8 or 9 and be 8 digits long"});
+    }
+
+    // Add validation for address
+    if (address.length > 150) {
+      return res.status(400).send({ message: "The address can only be up to 150 characters long"});
+    }
+
+    // Add validation for answer
+    if (answer.length > 50) {
+      return res.status(400).send({ message: "The answer can only be up to 50 characters long"});
     }
 
     //check user
@@ -98,7 +118,7 @@ export const loginController = async (req, res) => {
     //validation
     if (!email || !password) {
       // Changed error message to have same generic error message as below
-      return res.status(404).send({
+      return res.status(400).send({
         success: false,
         message: "Invalid email or password has been entered or email is not registered",
       });
@@ -107,16 +127,16 @@ export const loginController = async (req, res) => {
     const user = await userModel.findOne({ email });
     if (!user) {
       // Change error message as it should not reveal that email is not registered (Should just give generic message)
-      return res.status(404).send({
+      return res.status(400).send({
         success: false,
         message: "Invalid email or password has been entered or email is not registered",
       });
     }
     const match = await comparePassword(password, user.password);
     if (!match) {
-      // Change http status code to 404 instead of 200 which is for successful response case
+      // Change http status code to 400 instead of 200 which is for successful response case
       // Change error message as it should not reveal whether email is wrong or password is wrong (Security Reasons)
-      return res.status(404).send({
+      return res.status(400).send({
         success: false,
         message: "Invalid email or password has been entered or email is not registered",
       });
@@ -154,14 +174,31 @@ export const forgotPasswordController = async (req, res) => {
   try {
     const { email, answer, newPassword } = req.body;
     if (!email) {
-      res.status(400).send({ message: "Emai is required" });
+      return res.status(400).send({ message: "Email is required" });
     }
     if (!answer) {
-      res.status(400).send({ message: "answer is required" });
+      return res.status(400).send({ message: "An answer is required" });
     }
     if (!newPassword) {
-      res.status(400).send({ message: "New Password is required" });
+      return res.status(400).send({ message: "New Password is required" });
     }
+    
+    // Add validation for new password length (Need to be minimum of length 6)
+    if (newPassword.length < 6) {
+      return res.status(400).send({ message: "The length of the new password should be at least 6 characters long"});
+    }
+
+    // Add validation for email being used
+    const emailRegex = /^(?!^\.)(?!.*\.@)(?!.*\.{2})[a-zA-Z0-9.]{1,64}@(?!@\.)(?!.*\.$)(?!.*\.{2})[a-zA-Z0-9.]{1,64}$/;    
+    if (!email.match(emailRegex)) {
+      return res.status(400).send({ message: "The email is in an invalid format"});
+    }
+
+    // Add validation for answer
+    if (answer.length > 50) {
+      return res.status(400).send({ message: "The answer can only be up to 200 characters long"});
+    }
+
     //check
     const user = await userModel.findOne({ email, answer });
     //validation
@@ -200,12 +237,29 @@ export const testController = (req, res) => {
 //update prfole
 export const updateProfileController = async (req, res) => {
   try {
-    const { name, email, password, address, phone } = req.body;
+    const { name, password, address, phone } = req.body;
     const user = await userModel.findById(req.user._id);
     //password
     if (password && password.length < 6) {
       return res.json({ error: "Passsword is required and 6 character long" });
     }
+
+    // Add validation for name (Maximum 150 characters long)
+    if (name && name.length > 150) {
+      return res.status(400).send({ message: "The name can only be up to 150 characters long"});
+    }
+
+    // Add validation for phone number
+    const phoneRegex = /^[689]\d{7}$/;
+    if (phone && !phone.match(phoneRegex)) {
+      return res.status(400).send({ message: "The phone number must start with 6,8 or 9 and be 8 digits long"});
+    }
+
+    // Add validation for address
+    if (address && address.length > 50) {
+      return res.status(400).send({ message: "The address can only be up to 150 characters long"});
+    }
+
     const hashedPassword = password ? await hashPassword(password) : undefined;
     const updatedUser = await userModel.findByIdAndUpdate(
       req.user._id,
@@ -219,7 +273,7 @@ export const updateProfileController = async (req, res) => {
     );
     res.status(200).send({
       success: true,
-      message: "Profile Updated SUccessfully",
+      message: "Profile Updated Successfully",
       updatedUser,
     });
   } catch (error) {

--- a/controllers/tests/forgetPasswordController.test.js
+++ b/controllers/tests/forgetPasswordController.test.js
@@ -3,7 +3,9 @@ import { forgotPasswordController } from "../authController";
 import userModel from "../../models/userModel";
 import { ObjectId } from "mongodb";
 
-describe("Update Profile Controller Tests", () => {
+jest.mock("../../models/userModel.js");
+
+describe("Forget Password Controller Tests", () => {
     let req, res, user;
 
     beforeEach(() => {

--- a/controllers/tests/forgetPasswordController.test.js
+++ b/controllers/tests/forgetPasswordController.test.js
@@ -1,0 +1,174 @@
+import { expect, jest } from "@jest/globals";
+import { forgotPasswordController } from "../authController";
+import userModel from "../../models/userModel";
+import { ObjectId } from "mongodb";
+
+describe("Update Profile Controller Tests", () => {
+    let req, res, user;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        
+        req = {
+            body: {
+                email: "douglas@mail.com",
+                answer: "Football",
+                newPassword: "MoreThan6CharLong"
+            }
+          };
+
+          user = {
+            _id: new ObjectId("679f3c5eb35bb2db5e6a3646"),
+            name: 'Douglas Lim',
+            email: 'douglas@mail.com',
+            password: '$2b$10$qbvAri/zqZbK3PplhOFLM.SWfKecgXWjCOyv8S0le/fipAFhSxH4i',
+            phone: '97376721',
+            address: 'Beautiful Home on Earth',
+            role: 0
+          }
+      
+          res = {
+            status: jest.fn().mockReturnThis(),
+            send: jest.fn(),
+          };
+
+          userModel.findOne = jest.fn().mockResolvedValue(user);
+          userModel.findByIdAndUpdate = jest.fn().mockResolvedValue(null);
+    });
+
+    // Success case where user is able to reset their password with all valid fields
+    it('should allow the user to reset their password successfully with all valid fields', async () => {
+        await forgotPasswordController(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.send.mock.lastCall[0].message).toBe("Password Reset Successfully");
+    });
+
+    // Email
+    // Case where email is empty
+    it('should not allow the user to reset their password when their email is empty', async () => {
+        req.body.email = "";
+
+        await forgotPasswordController(req, res);
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.send.mock.lastCall[0].message).toBe("Email is required");
+    });
+
+    // Case where email is non-empty and invalid
+    it('should not allow the user to reset their password when their non-empty email is invalid', async () => {
+        req.body.email = "InvalidEmailShouldNotWork";
+
+        await forgotPasswordController(req, res);
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.send.mock.lastCall[0].message).toBe("The email is in an invalid format");
+    });
+
+    // Answer
+    // Case where answer is empty
+    it('should not allow the user to reset their password when their answer is empty', async () => {
+        req.body.answer = "";
+
+        await forgotPasswordController(req, res);
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.send.mock.lastCall[0].message).toBe("An answer is required");
+    });
+
+    // Case where answer is non-empty and invalid
+    it('should not allow the user to reset their password when their non-empty answer is invalid', async () => {
+        req.body.answer = "Basketball, Triple Jump, Cross country running, Half Marathon, Decathlon, Baseball, Volleyball, Rugby";
+
+        await forgotPasswordController(req, res);
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.send.mock.lastCall[0].message).toBe("The answer can only be up to 200 characters long");
+    });
+    
+    // Password
+    // Case where new password is empty
+    it('should not allow the user to reset their password when their new password is empty', async () => {
+        req.body.newPassword = "";
+
+        await forgotPasswordController(req, res);
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.send.mock.lastCall[0].message).toBe("New Password is required");
+    });
+
+    // Case where new password is non-empty and has a length less than 6
+    it('should not allow the user to reset their password when their non-empty password is of length 5', async () => {
+        req.body.newPassword = "5char";
+
+        await forgotPasswordController(req, res);
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.send.mock.lastCall[0].message).toBe("The length of the new password should be at least 6 characters long");
+    });
+
+    // Case where valid email, password and answer is given but user does not exist
+    it('should not allow the user to reset their password when the user does not exist', async () => {
+        userModel.findOne = jest.fn().mockResolvedValue(null);
+
+        await forgotPasswordController(req, res);
+        
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.send.mock.lastCall[0].message).toBe("Wrong Email Or Answer");
+    });
+
+    // Case where there is an error when connecting to the database
+    it('should throw an error when there is an error in connecting to the database', async () => {
+        userModel.findOne = jest.fn().mockImplementation(() => {
+            throw new Error("Error in connecting with database to retrieve user for resetting password");
+        });
+
+        await forgotPasswordController(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.send.mock.lastCall[0].message).toBe("Something went wrong");
+    });
+
+    /* Pairwise Testing Combination 1
+    Email: Valid
+    Answer: Invalid
+    New Password: Invalid
+    */
+   it('should not allow the user to reset their password when valid email, non-empty invalid answer and non-empty invalid new password is passed as input', async () => {
+    req.body.answer = "Basketball, Triple Jump, Cross country running, Half Marathon, Decathlon, Baseball, Volleyball, Rugby";
+    req.body.newPassword = "5char";
+
+    await forgotPasswordController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send.mock.lastCall[0].message).toBe("The length of the new password should be at least 6 characters long");
+   });
+
+
+   /* Pairwise Testing Combination 2
+   Email: Valid
+   Answer: Empty
+   New Password: Empty
+   */
+  it('should not allow the user to reset their password when valid email, empty answer and empty new password is passed as input', async () => {
+    req.body.answer = "";
+    req.body.newPassword = "";
+
+    await forgotPasswordController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send.mock.lastCall[0].message).toBe("An answer is required");    
+  });
+
+
+  /* Pairwise Testing Combination 3
+    Email: Invalid
+    Answer: Invalid
+    New Password: Empty
+  */
+  it('should not allow the user to reset their password when non-empty invalid email, non-empty invalid answer and empty new password is passed as input', async () => {
+    req.body.email = "InvalidEmailShouldNotWork";
+    req.body.answer = "Basketball, Triple Jump, Cross country running, Half Marathon, Decathlon, Baseball, Volleyball, Rugby";
+    req.body.newPassword = "";
+
+    await forgotPasswordController(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send.mock.lastCall[0].message).toBe("New Password is required");   
+  });
+
+});

--- a/controllers/tests/getOrdersController.test.js
+++ b/controllers/tests/getOrdersController.test.js
@@ -23,7 +23,7 @@ describe("Get Orders Controller Tests", () => {
         };
     }); 
 
-    // Case 1: Success case where the an orders made by the user can be obtained
+    // Case 1: Success case where the orders made by the user can be obtained
     it('should allow the user to get the list of orders that they have made', async () => {
 
         const firstMockProduct = {

--- a/controllers/tests/loginController.test.js
+++ b/controllers/tests/loginController.test.js
@@ -63,7 +63,7 @@ describe("Login Controller Tests", () => {
         userModel.findOne = jest.fn().mockResolvedValue(null);
 
         await loginController(req, res);
-        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.status).toHaveBeenCalledWith(400);
         expect(res.send.mock.lastCall[0].message).toBe("Invalid email or password has been entered or email is not registered");
         
         // Checks that it does not reach this method
@@ -75,7 +75,7 @@ describe("Login Controller Tests", () => {
         req.body.email = "non.existent.email@mail.com";
 
         await loginController(req, res);
-        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.status).toHaveBeenCalledWith(400);
         expect(res.send.mock.lastCall[0].message).toBe("Invalid email or password has been entered or email is not registered");
     });
 
@@ -87,7 +87,7 @@ describe("Login Controller Tests", () => {
         userModel.findOne = jest.fn().mockResolvedValue(null);
 
         await loginController(req, res);
-        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.status).toHaveBeenCalledWith(400);
         expect(res.send.mock.lastCall[0].message).toBe("Invalid email or password has been entered or email is not registered");
 
         // Checks that it does not reach this method
@@ -111,7 +111,7 @@ describe("Login Controller Tests", () => {
         req.body.password = "ThisShouldNotBeWorking";
 
         await loginController(req, res);
-        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.status).toHaveBeenCalledWith(400);
         expect(res.send.mock.lastCall[0].message).toBe("Invalid email or password has been entered or email is not registered");
     });
 

--- a/controllers/tests/registerController.test.js
+++ b/controllers/tests/registerController.test.js
@@ -1,6 +1,7 @@
 import { jest } from "@jest/globals";
 import { registerController } from "../authController";
 import userModel from "../../models/userModel";
+import { ObjectId } from "mongodb";
 
 jest.mock("../../models/userModel.js");
 
@@ -10,7 +11,7 @@ describe("Register Controller Tests", () => {
     beforeEach(() => {
       jest.clearAllMocks();
 
-      // Specifying the user model functionality (Similar to lab example)
+
       userModel.findOne = jest.fn().mockResolvedValue(null);
       userModel.prototype.save = jest.fn();
 
@@ -43,6 +44,7 @@ describe("Register Controller Tests", () => {
 
     });
   
+
     // Email (Equivalence partitioning) (There are 3 cases with valid email case already covered above)
     // Case 1: Empty email 
     it('should not allow user with empty email to be registered', async () => {
@@ -61,18 +63,15 @@ describe("Register Controller Tests", () => {
 
       await registerController(req, res);
 
-      // Check that http status is 404
-      expect(res.status).toHaveBeenCalledWith(404);
+      // Check that http status is 400
+      expect(res.status).toHaveBeenCalledWith(400);
       // Check that message shows that email is in invalid format
       expect(res.send.mock.lastCall[0].message).toBe("The email is in an invalid format");
 
     });
-
-    // Case 3: Non-empty email in valid format (In success test case above)
     
 
-
-    // Password (Equivalence Partitioning) (There are 3 cases with valid password case covered above)
+    // Password (Equivalence Partitioning) (There are 3 cases with valid password case already covered above)
     // Case 1: Empty password
     it('should not allow user with empty password to be registered', async () => {
 
@@ -91,13 +90,146 @@ describe("Register Controller Tests", () => {
 
       await registerController(req, res);
 
-      // Check that http status is 404
-      expect(res.status).toHaveBeenCalledWith(404);
-      // Check that message says that password is required
+      // Check that http status is 400
+      expect(res.status).toHaveBeenCalledWith(400);
+      // Check that message says that password should be at least 6 characters long
       expect(res.send.mock.lastCall[0].message).toBe("The length of the password should be at least 6 characters long");
     });
 
-    // Case 3: Non-empty password with length at least 6 characters long (In success test case above)
+
+    // Name (Equivalence Partitioning) (There are 3 cases with valid name case already covered above)
+    // Case 1: Empty Name
+    it('should not allow user with empty name to be registered', async () => {
+      req.body.name = "";
+
+      await registerController(req, res);
+
+      // Check that message says that name is required
+      expect(res.send.mock.lastCall[0].message).toBe("Name is Required");
+    });
+    
+    
+    // Case 2: Non-empty name with length more than 150 characters
+    it('should not allow user with non-empty name of length 151 to be registered', async () => {
+      req.body.name = "John William Samuel Douglas Russell Wallace Brandon Blaine James Joseph Johnson Monrole Jefferson Theodore Timothy Reece Franklin Charles Watson Holmes";
+
+      await registerController(req, res);
+
+      // Check that http status is 400
+      expect(res.status).toHaveBeenCalledWith(400);
+      // Check that message says that name should be at more 150 characters long
+      expect(res.send.mock.lastCall[0].message).toBe("The name can only be up to 150 characters long");
+    });
+
+
+    // Phone (Equivalence Partitioning) (There are 3 cases with valid phone case already covered above)
+    // Case 1: Empty phone number
+    it('should not allow user with empty phone number to be registered', async () => {
+      req.body.phone = "";
+
+      await registerController(req, res);
+
+      // Check that message says that phone number is required
+      expect(res.send.mock.lastCall[0].message).toBe("Phone no is Required");
+    });
+    
+    
+    // Case 2: Non-empty invalid phone number that does not start with 6,8 or 9 and be 8 digits long
+    it('should not allow user with non-empty invalid phone number that does not start with 6, 8 or 9 to be registered', async () => {
+      req.body.phone = "12391021";
+
+      await registerController(req, res);
+
+      // Check that http status is 400
+      expect(res.status).toHaveBeenCalledWith(400);
+      // Check that message says that phone number needs to start with 6,8 or 9 and be 8 digits long
+      expect(res.send.mock.lastCall[0].message).toBe("The phone number must start with 6,8 or 9 and be 8 digits long");
+    });
+
+
+    // Address (Equivalence Partitioning) (There are 3 cases with valid address case already covered above)
+    // Case 1: Empty address
+    it('should not allow user with empty address to be registered', async () => {
+      req.body.address = "";
+
+      await registerController(req, res);
+
+      // Check that message says that address is required
+      expect(res.send.mock.lastCall[0].message).toBe("Address is Required");
+    });
+
+    // Case 2: Non-empty invalid address that is more than 150 characters long
+    it('should not allow user with non-empty invalid address of length 151 to be registered', async () => {
+      req.body.address = "This is an extremely long long address with more than one hundred and fifty characters and this should not be allowed when trying to update the profile";
+  
+      await registerController(req, res);
+
+      // Check that http status is 400
+      expect(res.status).toHaveBeenCalledWith(400);
+      // Check that message says that address can only be up to 150 characters long
+      expect(res.send.mock.lastCall[0].message).toBe("The address can only be up to 150 characters long");
+    });
+
+
+    // Answer (Equivalence Partitioning) (There are 3 cases with valid answer case already covered above)
+    // Case 1: Empty answer
+    it('should not allow user with empty answer to be registered', async () => {
+      req.body.answer = "";
+
+      await registerController(req, res);
+
+      // Check that message says that answer is required
+      expect(res.send.mock.lastCall[0].message).toBe("Answer is Required");
+    });
+
+    // Case 2: Non-empty invalid answer that is more than 50 characters long
+    it('should not allow user with non-empty invalid answer of length 51 to be registered', async () => {
+      req.body.answer = "Basketball, Triple Jump, Cross country running, Half Marathon, Decathlon, Baseball, Volleyball, Rugby";
+  
+      await registerController(req, res);
+
+      // Check that http status is 400
+      expect(res.status).toHaveBeenCalledWith(400);
+      // Check that message says that answer can only be up to 50 characters long
+      expect(res.send.mock.lastCall[0].message).toBe("The answer can only be up to 50 characters long");
+    });
+
+
+    // Case where all fields are valid but email is already used
+    it('should not allow user with a used email to be registered', async () => {
+      const user = {
+        _id: new ObjectId("679f3c5eb35bb2db5e6a3646"),
+        name: 'Douglas Lim',
+        email: 'douglas@mail.com',
+        password: '$2b$10$qbvAri/zqZbK3PplhOFLM.SWfKecgXWjCOyv8S0le/fipAFhSxH4i',
+        phone: '97376721',
+        address: 'Beautiful Home on Earth',
+        role: 0
+      }
+
+      userModel.findOne = jest.fn().mockResolvedValue(user);
+
+      await registerController(req, res);
+
+      // Check that http status is 200
+      expect(res.status).toHaveBeenCalledWith(200);
+      // Check that message says that the user is already registered and to login
+      expect(res.send.mock.lastCall[0].message).toBe("Already Register please login");
+    });
+
+    // Case where error is handled when the user encounters an error connecting to database
+    it('should throw an error when the user faces an error in connecting to database', async () => {
+      userModel.findOne = jest.fn().mockImplementation(() => {
+        throw new Error("Error in connecting with database to check for existing user")
+      });
+
+      await registerController(req, res);
+
+      // Check that http status is 500
+      expect(res.status).toHaveBeenCalledWith(500);
+      // Check that message says that there is an error in registration
+      expect(res.send.mock.lastCall[0].message).toBe("Error in Registration");
+    });
 
   });
   

--- a/controllers/tests/updateProfileController.test.js
+++ b/controllers/tests/updateProfileController.test.js
@@ -1,0 +1,241 @@
+import { jest } from "@jest/globals";
+import { updateProfileController } from "../authController";
+import userModel from "../../models/userModel";
+import { ObjectId } from "mongodb";
+
+jest.mock("../../models/userModel.js");
+
+describe("Update Profile Controller Tests", () => {
+    let req, res, user, updatedUser;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        
+        req = {
+            body: {
+              name: "Douglas Lim",
+              password: "SomeRandomPasswordHere123",
+              phone: "90183289",
+              address: "6 Short Street"
+            },
+
+            user: {
+              _id: "679f3c5eb35bb2db5e6a3646"
+            }
+          };
+
+          user = {
+            _id: new ObjectId("679f3c5eb35bb2db5e6a3646"),
+            name: 'Douglas Lim',
+            email: 'douglas@mail.com',
+            password: '$2b$10$qbvAri/zqZbK3PplhOFLM.SWfKecgXWjCOyv8S0le/fipAFhSxH4i',
+            phone: '97376721',
+            address: 'Beautiful Home on Earth',
+            role: 0
+          }
+      
+          res = {
+            status: jest.fn().mockReturnThis(),
+            send: jest.fn(),
+            json: jest.fn()
+          };
+
+          userModel.findById = jest.fn().mockResolvedValue(user);
+    });
+
+    // Success case: Should allow the user to update the profile successfully with all valid fields
+    it("should allow the user to update the profile successfully", async () => {
+
+      updatedUser = {
+        _id: new ObjectId("679f3c5eb35bb2db5e6a3646"),
+        name: req.body.name || user.name,
+        email: 'douglas@mail.com',
+        password: req.body.password || user.password,
+        phone: req.body.phone || user.phone,
+        address: req.body.address || user.address,
+        role: 0
+      }
+
+      userModel.findByIdAndUpdate = jest.fn().mockResolvedValue(updatedUser);
+
+      await updateProfileController(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send.mock.lastCall[0].message).toBe("Profile Updated Successfully");
+    });
+
+    // Password
+    // Case where invalid password with length less than 6 is used for updating the profile
+    it('should not allow the user to update the profile with a password of length 5', async () => {
+      req.body.password = "SHORT";
+      await updateProfileController(req, res);
+      
+      expect(res.json.mock.lastCall[0].error).toBe("Passsword is required and 6 character long");
+    });
+
+    // Case where empty password is used for updating the profile (Should allow for updating by using the previous password)
+    it('should allow the user to update the profile with empty password', async () => {
+      req.body.password = "";
+
+      updatedUser = {
+        _id: new ObjectId("679f3c5eb35bb2db5e6a3646"),
+        name: req.body.name || user.name,
+        email: 'douglas@mail.com',
+        password: req.body.password || user.password,
+        phone: req.body.phone || user.phone,
+        address: req.body.address || user.address,
+        role: 0
+      }
+
+      userModel.findByIdAndUpdate = jest.fn().mockResolvedValue(updatedUser);
+
+      await updateProfileController(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send.mock.lastCall[0].message).toBe("Profile Updated Successfully");
+    });
+
+    // Name
+    // Case where invalid name with length more than 150 characters is used for updating the profile
+    it('should not allow the user to update the profile with a name that is of length 151', async () => {
+      req.body.name = "John William Samuel Douglas Russell Wallace Brandon Blaine James Joseph Johnson Monrole Jefferson Theodore Timothy Reece Franklin Charles Watson Holmes";
+      
+      await updateProfileController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.send.mock.lastCall[0].message).toBe("The name can only be up to 150 characters long");
+    });
+
+    // Case where empty name is used for updating the profile (Should allow for updating by using the previous name)
+    it('should allow the user to update the profile with empty name', async () => {
+      req.body.name = "";
+
+      updatedUser = {
+        _id: new ObjectId("679f3c5eb35bb2db5e6a3646"),
+        name: req.body.name || user.name,
+        email: 'douglas@mail.com',
+        password: req.body.password || user.password,
+        phone: req.body.phone || user.phone,
+        address: req.body.address || user.address,
+        role: 0
+      }
+
+      userModel.findByIdAndUpdate = jest.fn().mockResolvedValue(updatedUser);
+
+      await updateProfileController(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send.mock.lastCall[0].message).toBe("Profile Updated Successfully");
+    });
+
+    // Phone
+    // Case where invalid phone number which does not start with 6,8,9 is used for updating the profile
+    it('should not allow the user to update the profile with a number that does not start with 6,8 or 9', async () => {
+      req.body.phone = "12345678";
+
+      await updateProfileController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.send.mock.lastCall[0].message).toBe("The phone number must start with 6,8 or 9 and be 8 digits long");
+    });
+
+
+    // Case where empty phone number is used for updating the profile (Should allow for updating by using the previous phone number)
+    it('should allow the user to update the profile with empty phone number', async () => {
+      req.body.phone = "";
+
+      updatedUser = {
+        _id: new ObjectId("679f3c5eb35bb2db5e6a3646"),
+        name: req.body.name || user.name,
+        email: 'douglas@mail.com',
+        password: req.body.password || user.password,
+        phone: req.body.phone || user.phone,
+        address: req.body.address || user.address,
+        role: 0
+      }
+
+      userModel.findByIdAndUpdate = jest.fn().mockResolvedValue(updatedUser);
+
+      await updateProfileController(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send.mock.lastCall[0].message).toBe("Profile Updated Successfully");
+    });
+    
+    // Address
+    // Case where invalid address with more than 150 characters is used for updating the profile
+    it('should not allow the user to update the profile with a address that is 151 characters long', async () => {
+      req.body.address = "This is an extremely long long address with more than one hundred and fifty characters and this should not be allowed when trying to update the profile";
+
+      await updateProfileController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.send.mock.lastCall[0].message).toBe("The address can only be up to 150 characters long");
+    });
+
+
+    // Case where empty address is used for updating the profile (Should allow for updating by using the previous address)
+    it('should allow the user to update the profile with empty address', async () => {
+      req.body.address = "";
+
+      updatedUser = {
+        _id: new ObjectId("679f3c5eb35bb2db5e6a3646"),
+        name: req.body.name || user.name,
+        email: 'douglas@mail.com',
+        password: req.body.password || user.password,
+        phone: req.body.phone || user.phone,
+        address: req.body.address || user.address,
+        role: 0
+      }
+
+      userModel.findByIdAndUpdate = jest.fn().mockResolvedValue(updatedUser);
+
+      await updateProfileController(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send.mock.lastCall[0].message).toBe("Profile Updated Successfully");
+    });
+
+    // Add pairwise testing cases
+    /* Pairwise Combination 1
+      Name: Valid
+      Pasword: Valid
+      Phone: Non-empty invalid
+      Address: Empty
+    */
+    it('should not allow the user to update their profile when valid name, valid password, non-empty invalid phone number and empty address is passed as input', async () => {
+      req.body.phone = "22345678";
+      req.body.address = "";
+
+      await updateProfileController(req, res);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.send.mock.lastCall[0].message).toBe("The phone number must start with 6,8 or 9 and be 8 digits long");
+    });
+
+    /* Pairwise Combination 2
+      Name: Valid
+      Password: Empty
+      Phone: Valid
+      Address: Non-empty invalid
+    */
+    it('should not allow the user to update their profile when valid name, empty passowrd, valid phone number and non-empty invalid address is passed in as input', async () => {
+    req.body.password = "";
+    req.body.address = "This is an extremely long long address with more than one hundred and fifty characters and this should not be allowed when trying to update the profile";
+
+    await updateProfileController(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send.mock.lastCall[0].message).toBe("The address can only be up to 150 characters long");
+    });
+
+   /* Pairwise Combination 3 
+    Name: Valid
+    Password: Non-empty Invalid
+    Phone: Empty
+    Address: Valid
+   */
+    it('should not allow the user to update their profile when valid name, non-empty invalid password, empty phone number and valid address is passed in as input', async () => {
+      req.body.password = "5char";
+      req.body.phone = "";
+
+      await updateProfileController(req, res);
+      expect(res.json.mock.lastCall[0].error).toBe("Passsword is required and 6 character long");
+    });
+
+});


### PR DESCRIPTION
Added tests for Forget Password Controller, Update Profile Controller, Register Controller
Forget Password Controller
- Success case
- Email (Empty, Invalid)
- Answer (Empty, Invalid)
- Password (Empty, Invalid)
- Valid Email, Password and Answer but user does not exist
- Error when connecting to db
- 2 Pairwise Combinations

Update Profile Controller
- Success case
- Name (Empty, Invalid)
- Password (Empty, Invalid)
- Phone (Empty, Invalid)
- Address (Empty, Invalid)
- 3 Pairwise Combinations
