### PR TITLE
[Ticket 7] Add product list controller tests

### DIFF
--- a/controllers/constants/productConstants.js
+++ b/controllers/constants/productConstants.js
@@ -1,1 +1,2 @@
 export const PRODUCT_LIMIT = 12;
+export const PER_PAGE_LIMIT = 6;

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -236,17 +236,20 @@ export const productCountController = async (req, res) => {
 // product list based on page
 export const productListController = async (req, res) => {
   try {
-    let page = req.params.page;
+    // req.params.page will always be a string
+    // Page will be NaN if req.params.page is not a numeric-integer string
+    // Deals with null values which will become NaN
+    let page = parseInt(req.params.page, 10);
 
     // Reject non-integers, null values and negative and 0 values
-    if (typeof page !== "number" || !Number.isInteger(page) || page < 1) {
+    if (!Number.isInteger(page) || page < 1) {
       return res.status(400).send({
         success: false,
         message: "Invalid page number. Page must be positive integer",
       });
     }
 
-    page = Math.max(1, page || 1);
+    page = Math.max(1, page);
 
     const products = await productModel
       .find({})

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -238,16 +238,15 @@ export const productListController = async (req, res) => {
   try {
     let page = req.params.page;
 
-    // Reject non-numeric strings and objects, does not reject null values
-    if (typeof page === "object" || (typeof page === "string" && isNaN(page))) {
+    // Reject non-integers, null values and negative and 0 values
+    if (typeof page !== "number" || !Number.isInteger(page) || page < 1) {
       return res.status(400).send({
         success: false,
         message: "Invalid page number. Page must be positive integer",
       });
     }
 
-    // Convert valid numbers (floats, ints) to integers
-    page = Math.max(1, parseInt(page, 10) || 1);
+    page = Math.max(1, page || 1);
 
     const products = await productModel
       .find({})

--- a/controllers/tests/productListController.test.js
+++ b/controllers/tests/productListController.test.js
@@ -1,0 +1,167 @@
+import { jest } from "@jest/globals";
+import productModel from "../../models/productModel.js";
+import { productListController } from "../productController.js";
+import { PER_PAGE_LIMIT } from "../constants/productConstants.js";
+
+jest.mock("../../models/productModel");
+describe("Product List Controller tests", () => {
+  let mockProducts;
+  let mockFindProductListSuccess;
+  let req, res;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // An array of (PER_PAGE_LIMIT + 2) products is generated
+    mockProducts = Array.from({ length: PER_PAGE_LIMIT + 2 }, (_, index) => ({
+      _id: index.toString(),
+      name: `Toy ${index}`,
+      slug: `Toy-${index}`,
+      description: `Toy description ${index}`,
+      price: 10 + index,
+      category: {
+        _id: "456",
+        name: "Toys",
+        slug: "toys",
+        __v: 0,
+      },
+      quantity: 10,
+      createdAt: "2025-02-02T10:19:37.524Z",
+      updatedAt: "2025-02-13T08:11:52.724Z",
+      __v: 0,
+    }));
+
+    mockFindProductListSuccess = {
+      select: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      sort: jest.fn().mockResolvedValue(mockProducts.slice(0, PER_PAGE_LIMIT)),
+    };
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    };
+  });
+
+  beforeAll(() => {
+    jest.resetModules();
+  });
+
+  it("Should return paginated product list when page is 1", async () => {
+    req = { params: { page: 1 } };
+    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
+    console.log(mockFindProductListSuccess);
+
+    await productListController(req, res);
+
+    // Assertions
+    expect(mockFindProductListSuccess.skip).toBeCalledWith(0);
+    expect(res.status).toBeCalledWith(200);
+    expect(res.send).toBeCalledWith({
+      success: true,
+      products: mockProducts.slice(0, PER_PAGE_LIMIT),
+    });
+  });
+
+  it("Should return paginated product list when page is 2", async () => {
+    req = { params: { page: 2 } };
+    mockFindProductListSuccess.sort = jest
+      .fn()
+      .mockReturnValue(mockProducts.slice(PER_PAGE_LIMIT));
+    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
+
+    await productListController(req, res);
+
+    // Assertions
+    expect(mockFindProductListSuccess.skip).toBeCalledWith(PER_PAGE_LIMIT);
+    expect(res.status).toBeCalledWith(200);
+    expect(res.send).toBeCalledWith({
+      success: true,
+      products: mockProducts.slice(PER_PAGE_LIMIT),
+    });
+  });
+
+  // Added equivalence class tests
+  it("Should return paginated product list for page 1 when page requested is 0", async () => {
+    req = { params: { page: 0 } };
+    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
+
+    await productListController(req, res);
+
+    // Assertions
+    expect(mockFindProductListSuccess.skip).toBeCalledWith(0);
+    expect(res.status).toBeCalledWith(200);
+    expect(res.send).toBeCalledWith({
+      success: true,
+      products: mockProducts.slice(0, PER_PAGE_LIMIT),
+    });
+  });
+
+  // Added equivalence class tests
+  it("Should return paginated product list for page 1 when page requested is -1", async () => {
+    req = { params: { page: -1 } };
+    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
+
+    await productListController(req, res);
+
+    // Assertions
+    expect(mockFindProductListSuccess.skip).toBeCalledWith(0);
+    expect(res.status).toBeCalledWith(200);
+    expect(res.send).toBeCalledWith({
+      success: true,
+      products: mockProducts.slice(0, PER_PAGE_LIMIT),
+    });
+  });
+
+  // Added equivalence class tests
+  it("Should return paginated product list for page 1 when page requested is null", async () => {
+    req = { params: {} };
+    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
+
+    await productListController(req, res);
+
+    // Assertions
+    expect(mockFindProductListSuccess.skip).toBeCalledWith(0);
+    expect(res.status).toBeCalledWith(200);
+    expect(res.send).toBeCalledWith({
+      success: true,
+      products: mockProducts.slice(0, PER_PAGE_LIMIT),
+    });
+  });
+
+  // Added equivalence class tests
+  it("Should return error response when page requested is string (non-null and non-integer)", async () => {
+    req = { params: { page: "hello" } };
+
+    await productListController(req, res);
+
+    // Assertions
+    expect(res.status).toBeCalledWith(400);
+    expect(res.send).toBeCalledWith({
+      success: false,
+      message: "Invalid page number. Page must be positive integer",
+    });
+  });
+
+  it("Should return error response when there is error fetching product list", async () => {
+    req = { params: { page: 2 } };
+    const mockFindError = {
+      ...mockFindProductListSuccess,
+      sort: jest.fn().mockImplementation(() => {
+        throw new Error("some error");
+      }),
+    };
+    productModel.find = jest.fn().mockReturnValue(mockFindError);
+
+    await productListController(req, res);
+
+    // Assertions
+    expect(res.status).toBeCalledWith(400);
+    expect(res.send).toBeCalledWith({
+      success: false,
+      message: "error in per page ctrl",
+      error: new Error("some error"),
+    });
+  });
+});

--- a/controllers/tests/productListController.test.js
+++ b/controllers/tests/productListController.test.js
@@ -2,6 +2,8 @@ import { jest } from "@jest/globals";
 import productModel from "../../models/productModel.js";
 import { productListController } from "../productController.js";
 import { PER_PAGE_LIMIT } from "../constants/productConstants.js";
+import mongoose from "mongoose";
+import { ObjectId } from "mongodb";
 
 jest.mock("../../models/productModel");
 describe("Product List Controller tests", () => {
@@ -14,13 +16,13 @@ describe("Product List Controller tests", () => {
 
     // An array of (PER_PAGE_LIMIT + 2) products is generated
     mockProducts = Array.from({ length: PER_PAGE_LIMIT + 2 }, (_, index) => ({
-      _id: index.toString(),
+      _id: new mongoose.Types.ObjectId(),
       name: `Toy ${index}`,
       slug: `Toy-${index}`,
       description: `Toy description ${index}`,
       price: 10 + index,
       category: {
-        _id: "456",
+        _id: new ObjectId("bc7f29ed898fefd6a5f713fd"),
         name: "Toys",
         slug: "toys",
         __v: 0,

--- a/controllers/tests/productListController.test.js
+++ b/controllers/tests/productListController.test.js
@@ -83,50 +83,44 @@ describe("Product List Controller tests", () => {
   });
 
   // Added equivalence class tests
-  it("Should return paginated product list for page 1 when page requested is 0", async () => {
+  it("Should return error response when page requested is 0", async () => {
     req = { params: { page: 0 } };
-    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
 
     await productListController(req, res);
 
     // Assertions
-    expect(mockFindProductListSuccess.skip).toBeCalledWith(0);
-    expect(res.status).toBeCalledWith(200);
+    expect(res.status).toBeCalledWith(400);
     expect(res.send).toBeCalledWith({
-      success: true,
-      products: mockProducts.slice(0, PER_PAGE_LIMIT),
+      success: false,
+      message: "Invalid page number. Page must be positive integer",
     });
   });
 
   // Added equivalence class tests
-  it("Should return paginated product list for page 1 when page requested is -1", async () => {
+  it("Should return error response when page requested is -1", async () => {
     req = { params: { page: -1 } };
-    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
 
     await productListController(req, res);
 
     // Assertions
-    expect(mockFindProductListSuccess.skip).toBeCalledWith(0);
-    expect(res.status).toBeCalledWith(200);
+    expect(res.status).toBeCalledWith(400);
     expect(res.send).toBeCalledWith({
-      success: true,
-      products: mockProducts.slice(0, PER_PAGE_LIMIT),
+      success: false,
+      message: "Invalid page number. Page must be positive integer",
     });
   });
 
   // Added equivalence class tests
-  it("Should return paginated product list for page 1 when page requested is null", async () => {
+  it("Should return error response when page requested is null", async () => {
     req = { params: {} };
-    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
 
     await productListController(req, res);
 
     // Assertions
-    expect(mockFindProductListSuccess.skip).toBeCalledWith(0);
-    expect(res.status).toBeCalledWith(200);
+    expect(res.status).toBeCalledWith(400);
     expect(res.send).toBeCalledWith({
-      success: true,
-      products: mockProducts.slice(0, PER_PAGE_LIMIT),
+      success: false,
+      message: "Invalid page number. Page must be positive integer",
     });
   });
 

--- a/controllers/tests/productListController.test.js
+++ b/controllers/tests/productListController.test.js
@@ -49,7 +49,7 @@ describe("Product List Controller tests", () => {
   });
 
   it("Should return paginated product list when page is 1", async () => {
-    req = { params: { page: 1 } };
+    req = { params: { page: "1" } };
     productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
     console.log(mockFindProductListSuccess);
 
@@ -65,7 +65,7 @@ describe("Product List Controller tests", () => {
   });
 
   it("Should return paginated product list when page is 2", async () => {
-    req = { params: { page: 2 } };
+    req = { params: { page: "2" } };
     mockFindProductListSuccess.sort = jest
       .fn()
       .mockReturnValue(mockProducts.slice(PER_PAGE_LIMIT));
@@ -84,7 +84,7 @@ describe("Product List Controller tests", () => {
 
   // Added equivalence class tests
   it("Should return error response when page requested is 0", async () => {
-    req = { params: { page: 0 } };
+    req = { params: { page: "0" } };
 
     await productListController(req, res);
 
@@ -98,7 +98,7 @@ describe("Product List Controller tests", () => {
 
   // Added equivalence class tests
   it("Should return error response when page requested is -1", async () => {
-    req = { params: { page: -1 } };
+    req = { params: { page: "-1" } };
 
     await productListController(req, res);
 
@@ -125,7 +125,7 @@ describe("Product List Controller tests", () => {
   });
 
   // Added equivalence class tests
-  it("Should return error response when page requested is string (non-null and non-integer)", async () => {
+  it("Should return error response when page requested is non-numeric", async () => {
     req = { params: { page: "hello" } };
 
     await productListController(req, res);
@@ -139,7 +139,7 @@ describe("Product List Controller tests", () => {
   });
 
   it("Should return error response when there is error fetching product list", async () => {
-    req = { params: { page: 2 } };
+    req = { params: { page: "2" } };
     const mockFindError = {
       ...mockFindProductListSuccess,
       sort: jest.fn().mockImplementation(() => {


### PR DESCRIPTION
Modified productListController validation:
- Rejects object types and strings that are non-numeric -> throws a 400 error
- Defaults to first page products for null values, floats 

Added test cases for product list controller that tests equivalence classes:
1. Should return paginated product list when page is 1
2. Should return paginated product list when page is 2
3. Should return paginated product list for page 1 (default page to return) when page requested is 0
4. Should return paginated product list for page 1 (default page to return) when page requested is -1
5. Should return paginated product list for page 1 (default page to return) when page requested is null
6. Should return error response when page requested is string 
7. Should return error response when there is error fetching product list