### PR TITLE
[Ticket 4] Add tests for delete product controller

### DIFF
--- a/controllers/constants/productConstants.js
+++ b/controllers/constants/productConstants.js
@@ -1,1 +1,2 @@
 export const PRODUCT_LIMIT = 12;
+export const PER_PAGE_LIMIT = 6;

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -236,17 +236,20 @@ export const productCountController = async (req, res) => {
 // product list based on page
 export const productListController = async (req, res) => {
   try {
-    let page = req.params.page;
+    // req.params.page will always be a string
+    // Page will be NaN if req.params.page is not a numeric-integer string
+    // Deals with null values which will become NaN
+    let page = parseInt(req.params.page, 10);
 
     // Reject non-integers, null values and negative and 0 values
-    if (typeof page !== "number" || !Number.isInteger(page) || page < 1) {
+    if (!Number.isInteger(page) || page < 1) {
       return res.status(400).send({
         success: false,
         message: "Invalid page number. Page must be positive integer",
       });
     }
 
-    page = Math.max(1, page || 1);
+    page = Math.max(1, page);
 
     const products = await productModel
       .find({})

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -1,6 +1,7 @@
 import productModel from "../models/productModel.js";
 import categoryModel from "../models/categoryModel.js";
 import orderModel from "../models/orderModel.js";
+import mongoose from "mongoose";
 
 import fs from "fs";
 import slugify from "slugify";
@@ -131,11 +132,11 @@ export const deleteProductController = async (req, res) => {
   try {
     const { pid } = req.params;
 
-    // check if pid is null
-    if (!pid) {
+    // check if pid is null or dpesn't correspond to mongoose object id type
+    if (!pid || !mongoose.Types.ObjectId.isValid(pid)) {
       return res.status(400).send({
         success: false,
-        message: "Product ID cannot be null",
+        message: "Invalid Product format",
       });
     }
 

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -129,7 +129,28 @@ export const productPhotoController = async (req, res) => {
 //delete controller
 export const deleteProductController = async (req, res) => {
   try {
-    await productModel.findByIdAndDelete(req.params.pid).select("-photo");
+    const { pid } = req.params;
+
+    // check if pid is null
+    if (!pid) {
+      return res.status(400).send({
+        success: false,
+        message: "Product ID cannot be null",
+      });
+    }
+
+    const deletedProduct = await productModel
+      .findByIdAndDelete(pid)
+      .select("-photo");
+
+    // check if product is deleted successfully
+    if (!deletedProduct) {
+      return res.status(404).send({
+        success: false,
+        message: "Product not found",
+      });
+    }
+
     res.status(200).send({
       success: true,
       message: "Product Deleted successfully",

--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -238,16 +238,15 @@ export const productListController = async (req, res) => {
   try {
     let page = req.params.page;
 
-    // Reject non-numeric strings and objects, does not reject null values
-    if (typeof page === "object" || (typeof page === "string" && isNaN(page))) {
+    // Reject non-integers, null values and negative and 0 values
+    if (typeof page !== "number" || !Number.isInteger(page) || page < 1) {
       return res.status(400).send({
         success: false,
         message: "Invalid page number. Page must be positive integer",
       });
     }
 
-    // Convert valid numbers (floats, ints) to integers
-    page = Math.max(1, parseInt(page, 10) || 1);
+    page = Math.max(1, page || 1);
 
     const products = await productModel
       .find({})

--- a/controllers/tests/deleteProductController.test.js
+++ b/controllers/tests/deleteProductController.test.js
@@ -1,0 +1,103 @@
+import { jest } from "@jest/globals";
+import productModel from "../../models/productModel.js";
+import { deleteProductController } from "../productController.js";
+
+jest.mock("../../models/productModel");
+
+describe("Delete Product Controller tests", () => {
+  let res, req;
+
+  const mockProduct = {
+    _id: "123",
+    name: "Toy Giraffe",
+    slug: "toy-giraffe",
+    description: "Some toy giraffe",
+    price: 10,
+    category: {
+      _id: "456",
+      name: "Toys",
+      slug: "toys",
+      __v: 0,
+    },
+    quantity: 12,
+    createdAt: "2025-02-02T10:19:37.524Z",
+    updatedAt: "2025-02-13T08:11:52.724Z",
+    __v: 0,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    res = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    };
+  });
+
+  beforeAll(() => {
+    jest.resetModules();
+  });
+
+  it("Should delete a product when product exists", async () => {
+    req = { params: { pid: "123" } };
+    productModel.findByIdAndDelete = jest.fn().mockReturnValue({
+      select: jest.fn().mockResolvedValue(mockProduct),
+    });
+
+    await deleteProductController(req, res);
+
+    // Assertions
+    expect(res.status).toBeCalledWith(200);
+    expect(res.send).toBeCalledWith({
+      success: true,
+      message: "Product Deleted successfully",
+    });
+  });
+
+  it("Should return error response if product is not found", async () => {
+    req = { params: { pid: "456" } };
+    productModel.findByIdAndDelete = jest
+      .fn()
+      .mockReturnValue({ select: jest.fn().mockResolvedValue(null) });
+
+    await deleteProductController(req, res);
+
+    // Assertions
+    expect(res.status).toBeCalledWith(404);
+    expect(res.send).toBeCalledWith({
+      success: false,
+      message: "Product not found",
+    });
+  });
+
+  it("Should return error response if pid is not defined", async () => {
+    req = { params: {} };
+
+    await deleteProductController(req, res);
+
+    // Assertions
+    expect(res.status).toBeCalledWith(400);
+    expect(res.send).toBeCalledWith({
+      success: false,
+      message: "Product ID cannot be null",
+    });
+  });
+
+  it("Should return error response when there is an internal error when deleting product", async () => {
+    req = { params: { pid: "123" } };
+    productModel.findByIdAndDelete = jest.fn().mockReturnValue({
+      select: jest.fn().mockImplementation(() => {
+        throw new Error("some error");
+      }),
+    });
+
+    await deleteProductController(req, res);
+
+    // Assertions
+    expect(res.status).toBeCalledWith(500);
+    expect(res.send).toBeCalledWith({
+      success: false,
+      message: "Error while deleting product",
+      error: new Error("some error"),
+    });
+  });
+});

--- a/controllers/tests/deleteProductController.test.js
+++ b/controllers/tests/deleteProductController.test.js
@@ -1,6 +1,7 @@
 import { jest } from "@jest/globals";
 import productModel from "../../models/productModel.js";
 import { deleteProductController } from "../productController.js";
+import { ObjectId } from "mongodb";
 
 jest.mock("../../models/productModel");
 
@@ -8,7 +9,7 @@ describe("Delete Product Controller tests", () => {
   let res, req;
 
   const mockProduct = {
-    _id: "123",
+    _id: new ObjectId("0A2463A6406A263EFF5B5F62"),
     name: "Toy Giraffe",
     slug: "toy-giraffe",
     description: "Some toy giraffe",
@@ -38,7 +39,7 @@ describe("Delete Product Controller tests", () => {
   });
 
   it("Should delete a product when product exists", async () => {
-    req = { params: { pid: "123" } };
+    req = { params: { pid: "0A2463A6406A263EFF5B5F62" } };
     productModel.findByIdAndDelete = jest.fn().mockReturnValue({
       select: jest.fn().mockResolvedValue(mockProduct),
     });
@@ -53,8 +54,8 @@ describe("Delete Product Controller tests", () => {
     });
   });
 
-  it("Should return error response if product is not found", async () => {
-    req = { params: { pid: "456" } };
+  it("Should return error response if product id is not found but is valid", async () => {
+    req = { params: { pid: "3373D6C5B1BCFB50E6461FF6" } };
     productModel.findByIdAndDelete = jest
       .fn()
       .mockReturnValue({ select: jest.fn().mockResolvedValue(null) });
@@ -69,7 +70,7 @@ describe("Delete Product Controller tests", () => {
     });
   });
 
-  it("Should return error response if pid is not defined", async () => {
+  it("Should return error response if product id is not defined", async () => {
     req = { params: {} };
 
     await deleteProductController(req, res);
@@ -78,12 +79,25 @@ describe("Delete Product Controller tests", () => {
     expect(res.status).toBeCalledWith(400);
     expect(res.send).toBeCalledWith({
       success: false,
-      message: "Product ID cannot be null",
+      message: "Invalid Product format",
+    });
+  });
+
+  it("Should return error response if product id does not conform to correct id format", async () => {
+    req = { params: { pid: "abc" } };
+
+    await deleteProductController(req, res);
+
+    // Assertions
+    expect(res.status).toBeCalledWith(400);
+    expect(res.send).toBeCalledWith({
+      success: false,
+      message: "Invalid Product format",
     });
   });
 
   it("Should return error response when there is an internal error when deleting product", async () => {
-    req = { params: { pid: "123" } };
+    req = { params: { pid: "3373D6C5B1BCFB50E6461FF6" } };
     productModel.findByIdAndDelete = jest.fn().mockReturnValue({
       select: jest.fn().mockImplementation(() => {
         throw new Error("some error");

--- a/controllers/tests/productListController.test.js
+++ b/controllers/tests/productListController.test.js
@@ -1,0 +1,167 @@
+import { jest } from "@jest/globals";
+import productModel from "../../models/productModel.js";
+import { productListController } from "../productController.js";
+import { PER_PAGE_LIMIT } from "../constants/productConstants.js";
+
+jest.mock("../../models/productModel");
+describe("Product List Controller tests", () => {
+  let mockProducts;
+  let mockFindProductListSuccess;
+  let req, res;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // An array of (PER_PAGE_LIMIT + 2) products is generated
+    mockProducts = Array.from({ length: PER_PAGE_LIMIT + 2 }, (_, index) => ({
+      _id: index.toString(),
+      name: `Toy ${index}`,
+      slug: `Toy-${index}`,
+      description: `Toy description ${index}`,
+      price: 10 + index,
+      category: {
+        _id: "456",
+        name: "Toys",
+        slug: "toys",
+        __v: 0,
+      },
+      quantity: 10,
+      createdAt: "2025-02-02T10:19:37.524Z",
+      updatedAt: "2025-02-13T08:11:52.724Z",
+      __v: 0,
+    }));
+
+    mockFindProductListSuccess = {
+      select: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      sort: jest.fn().mockResolvedValue(mockProducts.slice(0, PER_PAGE_LIMIT)),
+    };
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    };
+  });
+
+  beforeAll(() => {
+    jest.resetModules();
+  });
+
+  it("Should return paginated product list when page is 1", async () => {
+    req = { params: { page: 1 } };
+    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
+    console.log(mockFindProductListSuccess);
+
+    await productListController(req, res);
+
+    // Assertions
+    expect(mockFindProductListSuccess.skip).toBeCalledWith(0);
+    expect(res.status).toBeCalledWith(200);
+    expect(res.send).toBeCalledWith({
+      success: true,
+      products: mockProducts.slice(0, PER_PAGE_LIMIT),
+    });
+  });
+
+  it("Should return paginated product list when page is 2", async () => {
+    req = { params: { page: 2 } };
+    mockFindProductListSuccess.sort = jest
+      .fn()
+      .mockReturnValue(mockProducts.slice(PER_PAGE_LIMIT));
+    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
+
+    await productListController(req, res);
+
+    // Assertions
+    expect(mockFindProductListSuccess.skip).toBeCalledWith(PER_PAGE_LIMIT);
+    expect(res.status).toBeCalledWith(200);
+    expect(res.send).toBeCalledWith({
+      success: true,
+      products: mockProducts.slice(PER_PAGE_LIMIT),
+    });
+  });
+
+  // Added equivalence class tests
+  it("Should return paginated product list for page 1 when page requested is 0", async () => {
+    req = { params: { page: 0 } };
+    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
+
+    await productListController(req, res);
+
+    // Assertions
+    expect(mockFindProductListSuccess.skip).toBeCalledWith(0);
+    expect(res.status).toBeCalledWith(200);
+    expect(res.send).toBeCalledWith({
+      success: true,
+      products: mockProducts.slice(0, PER_PAGE_LIMIT),
+    });
+  });
+
+  // Added equivalence class tests
+  it("Should return paginated product list for page 1 when page requested is -1", async () => {
+    req = { params: { page: -1 } };
+    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
+
+    await productListController(req, res);
+
+    // Assertions
+    expect(mockFindProductListSuccess.skip).toBeCalledWith(0);
+    expect(res.status).toBeCalledWith(200);
+    expect(res.send).toBeCalledWith({
+      success: true,
+      products: mockProducts.slice(0, PER_PAGE_LIMIT),
+    });
+  });
+
+  // Added equivalence class tests
+  it("Should return paginated product list for page 1 when page requested is null", async () => {
+    req = { params: {} };
+    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
+
+    await productListController(req, res);
+
+    // Assertions
+    expect(mockFindProductListSuccess.skip).toBeCalledWith(0);
+    expect(res.status).toBeCalledWith(200);
+    expect(res.send).toBeCalledWith({
+      success: true,
+      products: mockProducts.slice(0, PER_PAGE_LIMIT),
+    });
+  });
+
+  // Added equivalence class tests
+  it("Should return error response when page requested is string (non-null and non-integer)", async () => {
+    req = { params: { page: "hello" } };
+
+    await productListController(req, res);
+
+    // Assertions
+    expect(res.status).toBeCalledWith(400);
+    expect(res.send).toBeCalledWith({
+      success: false,
+      message: "Invalid page number. Page must be positive integer",
+    });
+  });
+
+  it("Should return error response when there is error fetching product list", async () => {
+    req = { params: { page: 2 } };
+    const mockFindError = {
+      ...mockFindProductListSuccess,
+      sort: jest.fn().mockImplementation(() => {
+        throw new Error("some error");
+      }),
+    };
+    productModel.find = jest.fn().mockReturnValue(mockFindError);
+
+    await productListController(req, res);
+
+    // Assertions
+    expect(res.status).toBeCalledWith(400);
+    expect(res.send).toBeCalledWith({
+      success: false,
+      message: "error in per page ctrl",
+      error: new Error("some error"),
+    });
+  });
+});

--- a/controllers/tests/productListController.test.js
+++ b/controllers/tests/productListController.test.js
@@ -2,6 +2,8 @@ import { jest } from "@jest/globals";
 import productModel from "../../models/productModel.js";
 import { productListController } from "../productController.js";
 import { PER_PAGE_LIMIT } from "../constants/productConstants.js";
+import mongoose from "mongoose";
+import { ObjectId } from "mongodb";
 
 jest.mock("../../models/productModel");
 describe("Product List Controller tests", () => {
@@ -14,13 +16,13 @@ describe("Product List Controller tests", () => {
 
     // An array of (PER_PAGE_LIMIT + 2) products is generated
     mockProducts = Array.from({ length: PER_PAGE_LIMIT + 2 }, (_, index) => ({
-      _id: index.toString(),
+      _id: new mongoose.Types.ObjectId(),
       name: `Toy ${index}`,
       slug: `Toy-${index}`,
       description: `Toy description ${index}`,
       price: 10 + index,
       category: {
-        _id: "456",
+        _id: new ObjectId("bc7f29ed898fefd6a5f713fd"),
         name: "Toys",
         slug: "toys",
         __v: 0,

--- a/controllers/tests/productListController.test.js
+++ b/controllers/tests/productListController.test.js
@@ -83,50 +83,44 @@ describe("Product List Controller tests", () => {
   });
 
   // Added equivalence class tests
-  it("Should return paginated product list for page 1 when page requested is 0", async () => {
+  it("Should return error response when page requested is 0", async () => {
     req = { params: { page: 0 } };
-    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
 
     await productListController(req, res);
 
     // Assertions
-    expect(mockFindProductListSuccess.skip).toBeCalledWith(0);
-    expect(res.status).toBeCalledWith(200);
+    expect(res.status).toBeCalledWith(400);
     expect(res.send).toBeCalledWith({
-      success: true,
-      products: mockProducts.slice(0, PER_PAGE_LIMIT),
+      success: false,
+      message: "Invalid page number. Page must be positive integer",
     });
   });
 
   // Added equivalence class tests
-  it("Should return paginated product list for page 1 when page requested is -1", async () => {
+  it("Should return error response when page requested is -1", async () => {
     req = { params: { page: -1 } };
-    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
 
     await productListController(req, res);
 
     // Assertions
-    expect(mockFindProductListSuccess.skip).toBeCalledWith(0);
-    expect(res.status).toBeCalledWith(200);
+    expect(res.status).toBeCalledWith(400);
     expect(res.send).toBeCalledWith({
-      success: true,
-      products: mockProducts.slice(0, PER_PAGE_LIMIT),
+      success: false,
+      message: "Invalid page number. Page must be positive integer",
     });
   });
 
   // Added equivalence class tests
-  it("Should return paginated product list for page 1 when page requested is null", async () => {
+  it("Should return error response when page requested is null", async () => {
     req = { params: {} };
-    productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
 
     await productListController(req, res);
 
     // Assertions
-    expect(mockFindProductListSuccess.skip).toBeCalledWith(0);
-    expect(res.status).toBeCalledWith(200);
+    expect(res.status).toBeCalledWith(400);
     expect(res.send).toBeCalledWith({
-      success: true,
-      products: mockProducts.slice(0, PER_PAGE_LIMIT),
+      success: false,
+      message: "Invalid page number. Page must be positive integer",
     });
   });
 

--- a/controllers/tests/productListController.test.js
+++ b/controllers/tests/productListController.test.js
@@ -49,7 +49,7 @@ describe("Product List Controller tests", () => {
   });
 
   it("Should return paginated product list when page is 1", async () => {
-    req = { params: { page: 1 } };
+    req = { params: { page: "1" } };
     productModel.find = jest.fn().mockReturnValue(mockFindProductListSuccess);
     console.log(mockFindProductListSuccess);
 
@@ -65,7 +65,7 @@ describe("Product List Controller tests", () => {
   });
 
   it("Should return paginated product list when page is 2", async () => {
-    req = { params: { page: 2 } };
+    req = { params: { page: "2" } };
     mockFindProductListSuccess.sort = jest
       .fn()
       .mockReturnValue(mockProducts.slice(PER_PAGE_LIMIT));
@@ -84,7 +84,7 @@ describe("Product List Controller tests", () => {
 
   // Added equivalence class tests
   it("Should return error response when page requested is 0", async () => {
-    req = { params: { page: 0 } };
+    req = { params: { page: "0" } };
 
     await productListController(req, res);
 
@@ -98,7 +98,7 @@ describe("Product List Controller tests", () => {
 
   // Added equivalence class tests
   it("Should return error response when page requested is -1", async () => {
-    req = { params: { page: -1 } };
+    req = { params: { page: "-1" } };
 
     await productListController(req, res);
 
@@ -125,7 +125,7 @@ describe("Product List Controller tests", () => {
   });
 
   // Added equivalence class tests
-  it("Should return error response when page requested is string (non-null and non-integer)", async () => {
+  it("Should return error response when page requested is non-numeric", async () => {
     req = { params: { page: "hello" } };
 
     await productListController(req, res);
@@ -139,7 +139,7 @@ describe("Product List Controller tests", () => {
   });
 
   it("Should return error response when there is error fetching product list", async () => {
-    req = { params: { page: 2 } };
+    req = { params: { page: "2" } };
     const mockFindError = {
       ...mockFindProductListSuccess,
       sort: jest.fn().mockImplementation(() => {


### PR DESCRIPTION
Scenarios tested:
1. Delete a product when product exists (valid and existing pid)
2. Return error response if product is not found (valid but not existing pid)
3. Return error response if pid is not defined (invalid pid)
4. Return error response when there is an internal error when deleting product (Internal error response)

Validations added:
1. Check if pid is non-null before finding and deleting the product corresponding to pid
2. Check if product is found and deleted successfully before returning a success response