### PR TITLE
[Ticket 5] Product filter controller - basic test cases

### DIFF
--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -10,7 +10,7 @@ import dotenv from "dotenv";
 import {
   PRODUCT_LIMIT,
   RELATED_PRODUCT_LIMIT,
-  PER_PAGE_LIMIT
+  PER_PAGE_LIMIT,
 } from "./constants/productConstants.js";
 
 dotenv.config();
@@ -231,6 +231,31 @@ export const productFiltersController = async (req, res) => {
   try {
     const { checked, radio } = req.body;
     let args = {};
+    // checked validations
+    if (
+      !checked ||
+      !Array.isArray(checked) ||
+      (checked.length > 0 &&
+        !checked.every((id) => mongoose.Types.ObjectId.isValid(id)))
+    ) {
+      return res.status(400).send({
+        success: false,
+        message: "'checked' must be an array with valid category ids",
+      });
+    }
+
+    // radio validations
+    if (
+      !radio ||
+      !Array.isArray(radio) ||
+      (radio.length !== 2 && radio.length !== 0) ||
+      !radio.every((num) => typeof num === "number")
+    ) {
+      return res.status(400).send({
+        success: false,
+        message: "'radio' must an empty array or an array with two numbers",
+      });
+    }
     if (checked.length > 0) args.category = checked;
     if (radio.length) args.price = { $gte: radio[0], $lte: radio[1] };
     const products = await productModel.find(args);

--- a/controllers/tests/productFiltersController.test.js
+++ b/controllers/tests/productFiltersController.test.js
@@ -49,12 +49,34 @@ describe("Product Filters Controller tests", () => {
     jest.resetModules();
   });
 
-  describe("General functional test cases", () => {
+  /**
+   * Pairwise testing
+   * Product filters controller takes in 2 inputs, checked and radio.
+   * Each input has 2 general equivalence classes,
+   *
+   * where checked can be:
+   *
+   * 1. Valid (empty array, array with all valid category ids)
+   * 2. Invalid (null, array with not all valid category ids)
+   *
+   * and radio can be:
+   *
+   * 1. Valid (empty array, array where elements are numbers)
+   * 2. Invalid (null, non-array type, array with length != 2 and length != 0,
+   * array where not all elements are numbers)
+   *
+   * There are a total of 4 pairwise tests below to cover all pairs.
+   * It can also be seen that there is an AND relationship between checked
+   * and radio with regards to the success of the controller return.
+   */
+
+  describe("Pairwise test cases", () => {
+    // Pairwise test case: valid input for both checked and radio
     it("Should get filtered products successfully when valid input for both checked and radio", async () => {
       req = {
         body: {
-          checked: ["bc7f29ed898fefd6a5f713fd"],
-          radio: [10, 20],
+          checked: ["bc7f29ed898fefd6a5f713fd"], // valid
+          radio: [10, 20], // valid
         },
       };
 
@@ -71,10 +93,12 @@ describe("Product Filters Controller tests", () => {
         products: mockProducts,
       });
     });
+
+    // Pairwise test case: checked is valid but radio is invalid
     it("Should return a 400 error when valid input for checked but invalid input for radio", async () => {
       req = {
         body: {
-          checked: ["bc7f29ed898fefd6a5f713fd"],
+          checked: [], // valid
           radio: ["print", "helloworld"], // invalid input as radio elements must be numbers
         },
       };
@@ -89,11 +113,12 @@ describe("Product Filters Controller tests", () => {
       });
     });
 
+    // Pairwise test case: checked is invalid but radio is valid
     it("Should return a 400 error when invalid input for checked but valid input for radio", async () => {
       req = {
         body: {
           checked: ["12345"], // invalid input as checked elements must correspond to Mongoose ObjectId type format
-          radio: [10, 20],
+          radio: [], // valid
         },
       };
 
@@ -107,6 +132,7 @@ describe("Product Filters Controller tests", () => {
       });
     });
 
+    // Pairwise test case: both checked and radio are invalid
     it("Should return a 400 error when invalid input for both checked and radio", async () => {
       req = {
         body: {
@@ -124,81 +150,37 @@ describe("Product Filters Controller tests", () => {
         message: "'checked' must be an array with valid category ids",
       });
     });
-
-    it("Should return 400 error when there is an error in fetching filtered products", async () => {
-      req = {
-        body: {
-          checked: ["bc7f29ed898fefd6a5f713fd"], // valid
-          radio: [10, 20], // valid
-        },
-      };
-      productModel.find = jest.fn().mockImplementation(() => {
-        throw new Error("some error");
-      });
-
-      await productFiltersController(req, res);
-
-      // Assertions
-      expect(res.status).toBeCalledWith(400);
-      expect(res.send).toBeCalledWith({
-        success: false,
-        message: "Error WHile Filtering Products",
-        error: new Error("some error"),
-      });
-    });
   });
 
   /**
-   * Equivalence classes for the 2 given inputs:
+   * We can further split the two equivalence class for radio and checked further into
+   * more specific classes:
    *
    * For "checked":
    * 1. null (tested above)
-   * 2. empty array
+   * 2. empty array (tested above)
    * 3. non-array type
    * 4. array with all valid category ids (tested above)
    * 5. array with not all valid category ids (tested above)
    *
    * For "radio":
-   * 1. null
-   * 2. empty array
+   * 1. null (tested above)
+   * 2. empty array (tested above)
    * 3. non-array type
    * 4. array with length != 2 and length != 0
    * 5. array where elements are numbers (tested above)
    * 6. array where not all elements are numbers (tested above)
    *
-   *
-   * The remaining 6 test cases not tested in previous testcases (under general functional testcases)
+   * The remaining 3 equivalence cases not tested in previous testcases (under pairwise testcases)
    * will be enumerated below
    */
-  describe("Specific equivalence class testing", () => {
-    // test when checked is an empty array (valid input)
-    it("Should get filtered products when checked is an empty array (valid input)", async () => {
-      req = {
-        body: {
-          checked: [], // valid
-          radio: [10, 20], // valid
-        },
-      };
-
-      await productFiltersController(req, res);
-
-      // Assertions
-      expect(productModel.find).toHaveBeenCalledWith({
-        price: { $gte: 10, $lte: 20 },
-      });
-      expect(res.status).toBeCalledWith(200);
-      expect(res.send).toBeCalledWith({
-        success: true,
-        products: mockProducts,
-      });
-    });
-
-    // test when checked is a non-array type (invalid input)
-    it("Should return 400 error when checked is non-array type (invalid input)", async () => {
+  describe("More specific equivalence class testing", () => {
+    // test when checked is a non-array type (invalid input) and radio is a non-array type (invalid input)
+    it("Should return 400 error when checked is non-array type (invalid input) and radio is a non-array type (invalid input)", async () => {
       req = {
         body: {
           checked: {}, // invalid as it must be array type
-          radio: [10, 20], // valid
+          radio: "Hello", // invalid as it must be array type
         },
       };
 
@@ -212,72 +194,12 @@ describe("Product Filters Controller tests", () => {
       });
     });
 
-    // test when radio is null (invalid input)
-    it("Should return 400 error when radio is null (invalid input)", async () => {
-      req = {
-        body: {
-          checked: ["bc7f29ed898fefd6a5f713fd"], //valid
-          // radio is null
-        },
-      };
-
-      await productFiltersController(req, res);
-
-      // Assertions
-      expect(res.status).toBeCalledWith(400);
-      expect(res.send).toBeCalledWith({
-        success: false,
-        message: "'radio' must an empty array or an array with two numbers",
-      });
-    });
-
-    // test when radio is non-array type (invalid input)
-    it("Should return 400 error when radio is non-array type (invalid input)", async () => {
-      req = {
-        body: {
-          checked: ["bc7f29ed898fefd6a5f713fd"], // valid
-          radio: {}, // invalid as it must be array type
-        },
-      };
-
-      await productFiltersController(req, res);
-
-      // Assertions
-      expect(res.status).toBeCalledWith(400);
-      expect(res.send).toBeCalledWith({
-        success: false,
-        message: "'radio' must an empty array or an array with two numbers",
-      });
-    });
-
-    // test when radio is an empty array (valid input)
-    it("Should get filtered products when radio is an empty array (valid input)", async () => {
-      req = {
-        body: {
-          checked: ["bc7f29ed898fefd6a5f713fd"], // valid
-          radio: [], // valid
-        },
-      };
-
-      await productFiltersController(req, res);
-
-      // Assertions
-      expect(productModel.find).toHaveBeenCalledWith({
-        category: ["bc7f29ed898fefd6a5f713fd"],
-      });
-      expect(res.status).toBeCalledWith(200);
-      expect(res.send).toBeCalledWith({
-        success: true,
-        products: mockProducts,
-      });
-    });
-
     // test when radio is an array with length != 2 and length != 0 (invalid)
     it("Should return 400 error when radio is an array with length != 2 and length != 0", async () => {
       req = {
         body: {
           checked: ["bc7f29ed898fefd6a5f713fd"], // valid
-          radio: [10], // invalid as it must be array type
+          radio: [10], // invalid as array has length != 2 and length != 0
         },
       };
 
@@ -288,6 +210,30 @@ describe("Product Filters Controller tests", () => {
       expect(res.send).toBeCalledWith({
         success: false,
         message: "'radio' must an empty array or an array with two numbers",
+      });
+    });
+  });
+
+  describe("Testcases with regards to model errors", () => {
+    it("Should return 400 error when there is an error in fetching filtered products", async () => {
+      req = {
+        body: {
+          checked: ["bc7f29ed898fefd6a5f713fd"], // valid
+          radio: [10, 20], // valid
+        },
+      };
+      productModel.find = jest.fn().mockImplementation(() => {
+        throw new Error("Filter products error");
+      });
+
+      await productFiltersController(req, res);
+
+      // Assertions
+      expect(res.status).toBeCalledWith(400);
+      expect(res.send).toBeCalledWith({
+        success: false,
+        message: "Error WHile Filtering Products",
+        error: new Error("Filter products error"),
       });
     });
   });

--- a/controllers/tests/productFiltersController.test.js
+++ b/controllers/tests/productFiltersController.test.js
@@ -1,0 +1,295 @@
+import { jest } from "@jest/globals";
+import productModel from "../../models/productModel.js";
+import { productFiltersController } from "../productController.js";
+import { ObjectId } from "mongodb";
+
+jest.mock("../../models/productModel");
+describe("Product Filters Controller tests", () => {
+  let res, req;
+
+  const mockProducts = [
+    {
+      _id: new ObjectId("51f45420a784984f2942e609"),
+      name: "Toy Giraffe",
+      slug: "Toy-Giraffe",
+      description: "Some toy giraffe",
+      price: 10,
+      category: new ObjectId("bc7f29ed898fefd6a5f713fd"),
+      quantity: 12,
+      createdAt: "2025-02-02T10:19:37.524Z",
+      updatedAt: "2025-02-13T08:11:52.724Z",
+      __v: 0,
+    },
+    {
+      _id: new ObjectId("242ddde9effa794b93f20688"),
+      name: "Toy cars",
+      slug: "Toy-cars",
+      description: "some toy cars",
+      price: 15,
+      category: new ObjectId("bc7f29ed898fefd6a5f713fd"),
+      quantity: 1,
+      createdAt: "2025-02-02T10:19:37.524Z",
+      updatedAt: "2025-02-13T08:11:52.724Z",
+      __v: 0,
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    };
+
+    productModel.find = jest.fn().mockResolvedValue(mockProducts);
+  });
+
+  beforeAll(() => {
+    jest.resetModules();
+  });
+
+  describe("General functional test cases", () => {
+    it("Should get filtered products successfully when valid input for both checked and radio", async () => {
+      req = {
+        body: {
+          checked: ["bc7f29ed898fefd6a5f713fd"],
+          radio: [10, 20],
+        },
+      };
+
+      await productFiltersController(req, res);
+
+      // Assertions
+      expect(productModel.find).toHaveBeenCalledWith({
+        category: ["bc7f29ed898fefd6a5f713fd"],
+        price: { $gte: 10, $lte: 20 },
+      });
+      expect(res.status).toBeCalledWith(200);
+      expect(res.send).toBeCalledWith({
+        success: true,
+        products: mockProducts,
+      });
+    });
+    it("Should return a 400 error when valid input for checked but invalid input for radio", async () => {
+      req = {
+        body: {
+          checked: ["bc7f29ed898fefd6a5f713fd"],
+          radio: ["print", "helloworld"], // invalid input as radio elements must be numbers
+        },
+      };
+
+      await productFiltersController(req, res);
+
+      // Assertions
+      expect(res.status).toBeCalledWith(400);
+      expect(res.send).toBeCalledWith({
+        success: false,
+        message: "'radio' must an empty array or an array with two numbers",
+      });
+    });
+
+    it("Should return a 400 error when invalid input for checked but valid input for radio", async () => {
+      req = {
+        body: {
+          checked: ["12345"], // invalid input as checked elements must correspond to Mongoose ObjectId type format
+          radio: [10, 20],
+        },
+      };
+
+      await productFiltersController(req, res);
+
+      // Assertions
+      expect(res.status).toBeCalledWith(400);
+      expect(res.send).toBeCalledWith({
+        success: false,
+        message: "'checked' must be an array with valid category ids",
+      });
+    });
+
+    it("Should return a 400 error when invalid input for both checked and radio", async () => {
+      req = {
+        body: {
+          checked: null, // invalid as checked should not be null
+          radio: ["hello", "world"], // invalid input as radio elements must be numbers
+        },
+      };
+
+      await productFiltersController(req, res);
+
+      // Assertions
+      expect(res.status).toBeCalledWith(400);
+      expect(res.send).toBeCalledWith({
+        success: false,
+        message: "'checked' must be an array with valid category ids",
+      });
+    });
+  });
+
+  /**
+   * Equivalence classes for the 2 given inputs:
+   *
+   * For "checked":
+   * 1. null (tested above)
+   * 2. empty array
+   * 3. non-array type
+   * 4. array with all valid category ids (tested above)
+   * 5. array with not all valid category ids (tested above)
+   *
+   * For "radio":
+   * 1. null
+   * 2. empty array
+   * 3. non-array type
+   * 4. array with length != 2 and length != 0
+   * 5. array where elements are numbers (tested above)
+   * 6. array where not all elements are numbers (tested above)
+   *
+   *
+   * The remaining 6 test cases not tested in previous testcases (under general functional testcases)
+   * will be enumerated below
+   */
+  describe("Specific equivalence class testing", () => {
+    // test when checked is an empty array (valid input)
+    it("Should get filtered products when checked is an empty array (valid input)", async () => {
+      req = {
+        body: {
+          checked: [], // valid
+          radio: [10, 20], // valid
+        },
+      };
+
+      await productFiltersController(req, res);
+
+      // Assertions
+      expect(productModel.find).toHaveBeenCalledWith({
+        price: { $gte: 10, $lte: 20 },
+      });
+      expect(res.status).toBeCalledWith(200);
+      expect(res.send).toBeCalledWith({
+        success: true,
+        products: mockProducts,
+      });
+    });
+
+    // test when checked is a non-array type (invalid input)
+    it("Should return 400 error when checked is non-array type (invalid input)", async () => {
+      req = {
+        body: {
+          checked: {}, // invalid as it must be array type
+          radio: [10, 20], // valid
+        },
+      };
+
+      await productFiltersController(req, res);
+
+      // Assertions
+      expect(res.status).toBeCalledWith(400);
+      expect(res.send).toBeCalledWith({
+        success: false,
+        message: "'checked' must be an array with valid category ids",
+      });
+    });
+
+    // test when radio is null (invalid input)
+    it("Should return 400 error when radio is null (invalid input)", async () => {
+      req = {
+        body: {
+          checked: ["bc7f29ed898fefd6a5f713fd"], //valid
+          // radio is null
+        },
+      };
+
+      await productFiltersController(req, res);
+
+      // Assertions
+      expect(res.status).toBeCalledWith(400);
+      expect(res.send).toBeCalledWith({
+        success: false,
+        message: "'radio' must an empty array or an array with two numbers",
+      });
+    });
+
+    // test when radio is non-array type (invalid input)
+    it("Should return 400 error when radio is non-array type (invalid input)", async () => {
+      req = {
+        body: {
+          checked: ["bc7f29ed898fefd6a5f713fd"], // valid
+          radio: {}, // invalid as it must be array type
+        },
+      };
+
+      await productFiltersController(req, res);
+
+      // Assertions
+      expect(res.status).toBeCalledWith(400);
+      expect(res.send).toBeCalledWith({
+        success: false,
+        message: "'radio' must an empty array or an array with two numbers",
+      });
+    });
+
+    // test when radio is an empty array (valid input)
+    it("Should get filtered products when radio is an empty array (valid input)", async () => {
+      req = {
+        body: {
+          checked: ["bc7f29ed898fefd6a5f713fd"], // valid
+          radio: [], // valid
+        },
+      };
+
+      await productFiltersController(req, res);
+
+      // Assertions
+      expect(productModel.find).toHaveBeenCalledWith({
+        category: ["bc7f29ed898fefd6a5f713fd"],
+      });
+      expect(res.status).toBeCalledWith(200);
+      expect(res.send).toBeCalledWith({
+        success: true,
+        products: mockProducts,
+      });
+    });
+
+    // test when radio is an array with length != 2 and length != 0 (invalid)
+    it("Should return 400 error when radio is an array with length != 2 and length != 0", async () => {
+      req = {
+        body: {
+          checked: ["bc7f29ed898fefd6a5f713fd"], // valid
+          radio: [10], // invalid as it must be array type
+        },
+      };
+
+      await productFiltersController(req, res);
+
+      // Assertions
+      expect(res.status).toBeCalledWith(400);
+      expect(res.send).toBeCalledWith({
+        success: false,
+        message: "'radio' must an empty array or an array with two numbers",
+      });
+    });
+
+    // test when radio is an array with length != 2 and length != 0 (invalid)
+    it("Should return 400 error when radio is an array with length != 2 and length != 0", async () => {
+      req = {
+        body: {
+          checked: ["bc7f29ed898fefd6a5f713fd"], // valid
+          radio: [10, 20], // valid
+        },
+      };
+      productModel.find = jest.fn().mockImplementation(() => {
+        throw new Error("some error");
+      });
+
+      await productFiltersController(req, res);
+
+      // Assertions
+      expect(res.status).toBeCalledWith(400);
+      expect(res.send).toBeCalledWith({
+        success: false,
+        message: "Error WHile Filtering Products",
+        error: new Error("some error"),
+      });
+    });
+  });
+});

--- a/controllers/tests/productFiltersController.test.js
+++ b/controllers/tests/productFiltersController.test.js
@@ -124,6 +124,28 @@ describe("Product Filters Controller tests", () => {
         message: "'checked' must be an array with valid category ids",
       });
     });
+
+    it("Should return 400 error when there is an error in fetching filtered products", async () => {
+      req = {
+        body: {
+          checked: ["bc7f29ed898fefd6a5f713fd"], // valid
+          radio: [10, 20], // valid
+        },
+      };
+      productModel.find = jest.fn().mockImplementation(() => {
+        throw new Error("some error");
+      });
+
+      await productFiltersController(req, res);
+
+      // Assertions
+      expect(res.status).toBeCalledWith(400);
+      expect(res.send).toBeCalledWith({
+        success: false,
+        message: "Error WHile Filtering Products",
+        error: new Error("some error"),
+      });
+    });
   });
 
   /**
@@ -266,29 +288,6 @@ describe("Product Filters Controller tests", () => {
       expect(res.send).toBeCalledWith({
         success: false,
         message: "'radio' must an empty array or an array with two numbers",
-      });
-    });
-
-    // test when radio is an array with length != 2 and length != 0 (invalid)
-    it("Should return 400 error when radio is an array with length != 2 and length != 0", async () => {
-      req = {
-        body: {
-          checked: ["bc7f29ed898fefd6a5f713fd"], // valid
-          radio: [10, 20], // valid
-        },
-      };
-      productModel.find = jest.fn().mockImplementation(() => {
-        throw new Error("some error");
-      });
-
-      await productFiltersController(req, res);
-
-      // Assertions
-      expect(res.status).toBeCalledWith(400);
-      expect(res.send).toBeCalledWith({
-        success: false,
-        message: "Error WHile Filtering Products",
-        error: new Error("some error"),
       });
     });
   });


### PR DESCRIPTION
### Pairwise testing
Pairwise testing for radio and checked where each input can be valid/invalid.
Test cases for pairwise testing below:
1.  checked: valid, radio: valid
2. checked: valid, radio: invalid
3. checked: invalid, radio: valid
4. checked: invalid, radio: invalid

### Specific equivalence class testing
We can further split the two equivalence class for radio and checked further into more specific classes:

**For "checked":**
- Under valid:
  - empty array (tested above in pairwise)
  - array with all valid category ids (tested above in pairwise)
- Under invalid:
  - null (tested above in pairwise)
  - non-array type
  - array with not all valid category ids (tested above in pairwise)
 
**For "radio":**
- Under valid:
  - empty array (tested above in pairwise)
  - array where all elements are numbers (tested above in pairwise)
- Under invalid:
  - null (tested above in pairwise)
  - non-array type
  - array with length != 2 and length != 0
  - array where not all elements are numbers (tested above in  pairwise)

The remaining specific equivalence class not tested in pairwise (non-array type for checked; non-array type, array with length != 2 and length != 0 for radio) can then be tested.