### PR TITLE
[Ticket 3] Product photo controller - basic testcases

### DIFF
--- a/controllers/productController.js
+++ b/controllers/productController.js
@@ -123,7 +123,15 @@ export const getSingleProductController = async (req, res) => {
 // get photo
 export const productPhotoController = async (req, res) => {
   try {
-    const product = await productModel.findById(req.params.pid).select("photo");
+    // Check if pid is null or corresponds to mongoose object id type
+    const { pid } = req.params;
+    if (!pid || !mongoose.Types.ObjectId.isValid(pid)) {
+      return res.status(400).send({
+        success: false,
+        message: "Invalid Product id format",
+      });
+    }
+    const product = await productModel.findById(pid).select("photo");
     if (product.photo.data) {
       res.set("Content-type", product.photo.contentType);
       return res.status(200).send(product.photo.data);
@@ -143,7 +151,7 @@ export const deleteProductController = async (req, res) => {
   try {
     const { pid } = req.params;
 
-    // check if pid is null or dpesn't correspond to mongoose object id type
+    // check if pid is null or doesn't correspond to mongoose object id type
     if (!pid || !mongoose.Types.ObjectId.isValid(pid)) {
       return res.status(400).send({
         success: false,

--- a/controllers/tests/productPhotoController.test.js
+++ b/controllers/tests/productPhotoController.test.js
@@ -1,0 +1,86 @@
+import { jest } from "@jest/globals";
+import productModel from "../../models/productModel.js";
+import { productPhotoController } from "../productController.js";
+import { ObjectId } from "mongodb";
+
+jest.mock("../../models/productModel");
+describe("Product Photo Controller tests", () => {
+  let req, res;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    req = {
+      params: { pid: new ObjectId("242ddde9effa794b93f20688") },
+    };
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+      set: jest.fn(),
+    };
+  });
+
+  it("Should fetch a product photo successfully", async () => {
+    const mockProduct = {
+      photo: {
+        data: Buffer.from("some mocked image data"),
+        contentType: "image/jpeg",
+      },
+    };
+
+    productModel.findById = jest
+      .fn()
+      .mockReturnValue({ select: jest.fn().mockResolvedValue(mockProduct) });
+
+    await productPhotoController(req, res);
+
+    // Assertions
+    expect(res.set).toHaveBeenCalledWith("Content-type", "image/jpeg");
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith(mockProduct.photo.data);
+  });
+
+  it("Should return 400 error when pid is null", async () => {
+    req.params.pid = null;
+
+    await productPhotoController(req, res);
+
+    // Assertions
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith({
+      success: false,
+      message: "Invalid Product id format",
+    });
+  });
+
+  it("Should return 400 error when pid is non-mongoose Object ID format", async () => {
+    req.params.pid = "123";
+
+    await productPhotoController(req, res);
+
+    // Assertions
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith({
+      success: false,
+      message: "Invalid Product id format",
+    });
+  });
+
+  it("Should return error response when there is error fetching product photo", async () => {
+    productModel.findById = jest.fn().mockReturnValue({
+      select: jest.fn().mockImplementation(() => {
+        throw new Error("Error fetching product photo");
+      }),
+    });
+
+    await productPhotoController(req, res);
+
+    // Assertions
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.send).toHaveBeenCalledWith({
+      success: false,
+      message: "Error while getting photo",
+      error: new Error("Error fetching product photo"),
+    });
+  });
+});


### PR DESCRIPTION
- Augmented the validation of product photo controller
- Testcases covered include:
  - Success case: valid pid
  - Should return 400 error when pid is null
  - Should return 400 error when pid is non-mongoose Object ID format
  - Should return error response when there is error fetching product photo (DB-related error)