### PR TITLE
Test/admin pages protected UI tests

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -2,6 +2,7 @@ import { Routes, Route } from "react-router-dom";
 import HomePage from "./pages/HomePage";
 import About from "./pages/About";
 import Contact from "./pages/Contact";
+import Forbiddenpage from "./pages/Forbiddenpage";
 import Policy from "./pages/Policy";
 import Pagenotfound from "./pages/Pagenotfound";
 import Register from "./pages/Auth/Register";
@@ -52,6 +53,7 @@ function App() {
         <Route path="/about" element={<About />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/policy" element={<Policy />} />
+        <Route path="/forbidden" element={<Forbiddenpage />} />
         <Route path="*" element={<Pagenotfound />} />
       </Routes>
     </>

--- a/client/src/components/Routes/AdminRoute.js
+++ b/client/src/components/Routes/AdminRoute.js
@@ -6,32 +6,62 @@ import { useAuth } from "../../context/auth";
 import Spinner from "../Spinner";
 
 export default function AdminRoute() {
-  const [auth] = useAuth();
+  const [auth, setAuth] = useAuth();
   const token = useMemo(() => auth?.token, [auth]); // Avoid unnecessary re-renders
   const [state, setState] = useState({ loading: true, ok: false });
   const navigate = useNavigate();
 
   useEffect(() => {
     const checkAuth = async () => {
-      if (!token) {
-        navigate("/login");
-        return;
-      }
+      if (!auth?.token) {
+        const storedAuth = localStorage.getItem("auth");
+        if (storedAuth) {
+          const parsedAuth = JSON.parse(storedAuth);
+          setAuth(parsedAuth);
+          const token = parsedAuth.token;
 
-      try {
-        const { data } = await axios.get("/api/v1/auth/admin-auth");
-        setState({ loading: false, ok: data.ok });
-      } catch (error) {
-        console.error("Admin auth check failed:", error);
-        if (error.response.status == 401) {
-          navigate("/forbidden");
-          return;
+          try {
+            const response = await axios.get("/api/v1/auth/admin-auth", {
+              headers: {
+                Authorization: token,
+              },
+            });
+
+            setState({ loading: false, ok: response.data.ok });
+          } catch (error) {
+            if (error.response) {
+              // Failed token authorization check
+              navigate("/forbidden");
+            } else {
+              // Potentially network error
+              navigate("/login");
+            }
+          }
+        } else {
+          // No token in local storage and in auth context
+          navigate("/login");
+        }
+      } else {
+        try {
+          const response = await axios.get("/api/v1/auth/admin-auth", {
+            headers: {
+              Authorization: token,
+            },
+          });
+          setState({ loading: false, ok: response.data.ok });
+        } catch (error) {
+          if (error.response) {
+            // Failed token authorization check
+            navigate("/forbidden");
+          } else {
+            // Potentially network error
+            navigate("/login");
+          }
         }
       }
     };
-
     checkAuth();
-  }, [token]);
+  }, [auth?.token, token, navigate, setAuth]);
 
   return state.loading ? <Spinner /> : <Outlet />;
 }

--- a/client/src/components/Routes/AdminRoute.js
+++ b/client/src/components/Routes/AdminRoute.js
@@ -29,7 +29,7 @@ export default function AdminRoute() {
 
             setState({ loading: false, ok: response.data.ok });
           } catch (error) {
-            if (error.response) {
+            if (error.response.status === 401) {
               // Failed token authorization check
               navigate("/forbidden");
             } else {
@@ -50,7 +50,7 @@ export default function AdminRoute() {
           });
           setState({ loading: false, ok: response.data.ok });
         } catch (error) {
-          if (error.response) {
+          if (error.response.status === 401) {
             // Failed token authorization check
             navigate("/forbidden");
           } else {

--- a/client/src/components/Routes/AdminRoute.js
+++ b/client/src/components/Routes/AdminRoute.js
@@ -1,67 +1,57 @@
-import React from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import axios from "axios";
-import { useEffect, useMemo, useState } from "react";
 import { Outlet, useNavigate } from "react-router-dom";
 import { useAuth } from "../../context/auth";
 import Spinner from "../Spinner";
 
 export default function AdminRoute() {
   const [auth, setAuth] = useAuth();
-  const token = useMemo(() => auth?.token, [auth]); // Avoid unnecessary re-renders
   const [state, setState] = useState({ loading: true, ok: false });
   const navigate = useNavigate();
 
-  useEffect(() => {
-    const checkAuth = async () => {
-      if (!auth?.token) {
+  const checkAuth = useCallback(async () => {
+    try {
+      // Check if auth context has token already
+      let token = auth?.token;
+
+      // If not, try to get it from local storage
+      if (!token) {
         const storedAuth = localStorage.getItem("auth");
         if (storedAuth) {
           const parsedAuth = JSON.parse(storedAuth);
-          setAuth(parsedAuth);
-          const token = parsedAuth.token;
-
-          try {
-            const response = await axios.get("/api/v1/auth/admin-auth", {
-              headers: {
-                Authorization: token,
-              },
-            });
-
-            setState({ loading: false, ok: response.data.ok });
-          } catch (error) {
-            if (error.response.status === 401) {
-              // Failed token authorization check
-              navigate("/forbidden");
-            } else {
-              // Potentially network error
-              navigate("/login");
-            }
-          }
+          setAuth(parsedAuth); // Update auth context
+          token = parsedAuth.token;
         } else {
-          // No token in local storage and in auth context
+          // Update state before navigating to login
+          // Unauthenticated users (no token) go to login page
+          setState({ loading: false, ok: false });
           navigate("/login");
-        }
-      } else {
-        try {
-          const response = await axios.get("/api/v1/auth/admin-auth", {
-            headers: {
-              Authorization: token,
-            },
-          });
-          setState({ loading: false, ok: response.data.ok });
-        } catch (error) {
-          if (error.response.status === 401) {
-            // Failed token authorization check
-            navigate("/forbidden");
-          } else {
-            // Potentially network error
-            navigate("/login");
-          }
+          return;
         }
       }
-    };
+
+      const response = await axios.get("/api/v1/auth/admin-auth", {
+        headers: {
+          Authorization: token,
+        },
+      });
+
+      setState({ loading: false, ok: response.data.ok });
+    } catch (error) {
+      if (error.response?.status === 401) {
+        // Signed-in but non-admins, go to forbidden page
+        navigate("/forbidden");
+      } else {
+        // Other general errors (eg. Network error)
+        navigate("/login");
+      }
+      setState({ loading: false, ok: false });
+    }
+  }, [auth?.token, navigate, setAuth]);
+
+  useEffect(() => {
     checkAuth();
-  }, [auth?.token, token, navigate, setAuth]);
+  }, [checkAuth]);
 
   return state.loading ? <Spinner /> : <Outlet />;
 }

--- a/client/src/components/Routes/AdminRoute.test.js
+++ b/client/src/components/Routes/AdminRoute.test.js
@@ -100,16 +100,20 @@ describe("Admin Route Component", () => {
   });
 
   it("should render the loading spinner correctly", () => {
-    const { getByRole } = render(
-      <MemoryRouter initialEntries={["/dashboard"]}>
-        <Routes>
-          <Route path="/dashboard" element={<AdminRoute />}>
-            <Route path="" element={<p>Test Dashboard Route</p>} />
-          </Route>
-        </Routes>
+    // Mock auth with test token
+    useAuth.mockReturnValue([{ token: "test-token" }, jest.fn()]);
+
+    // Mock axios to never resolve during the test duration, so that Spinner will stay
+    axios.get.mockImplementation(() => new Promise(() => {}));
+
+    // Render the component
+    const { getByText } = render(
+      <MemoryRouter>
+        <AdminRoute />
       </MemoryRouter>
     );
 
-    expect(getByRole("status")).toBeInTheDocument();
+    // Check if mocked spinner is rendered
+    expect(getByText("Loading...")).toBeInTheDocument();
   });
 });

--- a/client/src/pages/Forbiddenpage.js
+++ b/client/src/pages/Forbiddenpage.js
@@ -1,0 +1,34 @@
+import React, { useEffect } from "react";
+import { Link } from "react-router-dom";
+import Layout from "./../components/Layout";
+
+const Forbiddenpage = () => {
+  // Update document title directly for SEO purposes when component is rendered
+  useEffect(() => {
+    const originalTitle = document.title;
+
+    document.title = "401 - Forbidden Page | Ecommerce App";
+
+    // Cleanup function for when component unmounts by resetting document title
+    return () => {
+      document.title = originalTitle;
+    };
+  }, []);
+
+  return (
+    <Layout title={"go back- forbidden page"}>
+      {/* Accessibility feature for assitive devices to show user 401 when page not found. */}
+      <div className="pnf" role="alert" aria-labelledby="pnf-heading">
+        <h1 id="error-title" className="pnf-title">
+          401
+        </h1>
+        <h2 className="pnf-heading">Oops ! This Page is forbidden</h2>
+        <Link to="/" className="pnf-btn">
+          Go Back
+        </Link>
+      </div>
+    </Layout>
+  );
+};
+
+export default Forbiddenpage;

--- a/routes/productRoutes.js
+++ b/routes/productRoutes.js
@@ -47,7 +47,12 @@ router.get("/get-product/:slug", getSingleProductController);
 router.get("/product-photo/:pid", productPhotoController);
 
 //delete rproduct
-router.delete("/delete-product/:pid", deleteProductController);
+router.delete(
+  "/delete-product/:pid",
+  requireSignIn,
+  isAdmin,
+  deleteProductController
+);
 
 //filter product
 router.post("/product-filters", productFiltersController);

--- a/ui-tests/unauthorisedAdminAccess.spec.js
+++ b/ui-tests/unauthorisedAdminAccess.spec.js
@@ -8,7 +8,7 @@ import userModel from "../models/userModel";
 dotenv.config();
 
 test.beforeEach(async ({ page }) => {
-  // Connect to DB so as to delete test user later
+  // Connect to DB so as to create and delete test user later
   await mongoose.connect(process.env.MONGO_URL);
   // Navigate to Home Page
   await page.goto("http://localhost:3000", { waitUntil: "commit" });

--- a/ui-tests/unauthorisedAdminAccess.spec.js
+++ b/ui-tests/unauthorisedAdminAccess.spec.js
@@ -1,0 +1,148 @@
+import { test, expect } from "@playwright/test";
+import dotenv from "dotenv";
+
+import mongoose from "mongoose";
+
+import userModel from "../models/userModel";
+
+dotenv.config();
+
+test.beforeEach(async ({ page }) => {
+  // Connect to DB so as to delete test user later
+  await mongoose.connect(process.env.MONGO_URL);
+  // Navigate to Home Page
+  await page.goto("http://localhost:3000", { waitUntil: "commit" });
+});
+
+test.describe("Unauthorised access to admin features", () => {
+  test.describe("Not logged-in users attempt", () => {
+    test.beforeEach(async ({ page }) => {
+      // Clear cookies/storage to ensure clean state
+      await page.context().clearCookies();
+    });
+    test("should redirect to login page", async ({ page }) => {
+      // Admin dashboard should not be accessible to unauthenticated users
+      await page.goto("http://localhost:3000/dashboard/admin", {
+        waitUntil: "domcontentloaded",
+      });
+      await expect(page).toHaveURL("http://localhost:3000/login");
+      // Create category page should not be accessible to unauthenticated users
+      await page.goto("http://localhost:3000/dashboard/admin/create-category", {
+        waitUntil: "domcontentloaded",
+      });
+      await expect(page).toHaveURL("http://localhost:3000/login");
+      // Create product page should not be accessible to unathenticated users
+      await page.goto("http://localhost:3000/dashboard/admin/create-product", {
+        waitUntil: "domcontentloaded",
+      });
+      await expect(page).toHaveURL("http://localhost:3000/login");
+      // Admin products page should not be accessible to unauthenticated users
+      await page.goto("http://localhost:3000/dashboard/admin/products", {
+        waitUntil: "domcontentloaded",
+      });
+      await expect(page).toHaveURL("http://localhost:3000/login");
+      //Admin orders page should not be accessible to uauthenticated users
+      await page.goto("http://localhost:3000/dashboard/admin/orders", {
+        waitUntil: "domcontentloaded",
+      });
+      await expect(page).toHaveURL("http://localhost:3000/login");
+    });
+  });
+
+  test.describe("Logged-in users (but not admin) attempt", () => {
+    test.beforeEach(async ({ page }) => {
+      // Create user for test
+      const hashedPassword =
+        "$2b$10$6yckf4REjQKwirxfh8Q30efR4RLp5mCBrPoluhz4kIVe.zat6uDO2";
+
+      await new userModel({
+        name: "Test User",
+        email: "notadmin@mail.com",
+        phone: "81234567",
+        address: "123 Test Road",
+        password: hashedPassword,
+        answer: "password is cs4218",
+      }).save();
+
+      // Navigating to home page
+      await page.goto("http://localhost:3000", { waitUntil: "commit" });
+    });
+    test.afterEach(async () => {
+      // Delete test user
+      await userModel.deleteMany({ email: "notadmin@mail.com" });
+      // Disconnect from DB
+      await mongoose.disconnect();
+    });
+
+    test("should only show non-admin items as links", async ({ page }) => {
+      // Navigating to login page
+      await page.getByRole("link", { name: "Login" }).click();
+
+      // Keying in correct email address but wrong password
+      await page
+        .getByRole("textbox", { name: "Enter Your Email" })
+        .fill("notadmin@mail.com");
+      await page
+        .getByRole("textbox", { name: "Enter Your Password" })
+        .fill("cs4218");
+      await page.getByRole("button", { name: "Login" }).click();
+
+      await page.getByRole("button", { name: "Test User" }).click();
+      await page.getByRole("link", { name: "Dashboard" }).click();
+      await expect(page.getByRole("link", { name: "Profile" })).toBeVisible();
+      await expect(page.getByRole("link", { name: "Orders" })).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: "Create Category" })
+      ).not.toBeVisible();
+      await expect(
+        page.getByRole("link", { name: "Create Product" })
+      ).not.toBeVisible();
+      await expect(
+        page.getByRole("link", { name: "Products" })
+      ).not.toBeVisible();
+
+      await page.getByRole("link", { name: "Profile" }).click();
+
+      await expect(page).toHaveURL(
+        "http://localhost:3000/dashboard/user/profile"
+      );
+
+      await page.goBack({ waitUntil: "commit" });
+
+      await page.getByRole("link", { name: "Orders" }).click();
+
+      await expect(page).toHaveURL(
+        "http://localhost:3000/dashboard/user/orders"
+      );
+    });
+
+    // TODO: Might change to redirecting to forbidden page instead since user is technically logged in
+    test("should redirect to login page", async ({ page }) => {
+      // Admin dashboard should not be accessible to unauthenticated users
+      await page.goto("http://localhost:3000/dashboard/admin", {
+        waitUntil: "domcontentloaded",
+      });
+      await expect(page).toHaveURL("http://localhost:3000/login");
+      // Create category page should not be accessible to unauthenticated users
+      await page.goto("http://localhost:3000/dashboard/admin/create-category", {
+        waitUntil: "domcontentloaded",
+      });
+      await expect(page).toHaveURL("http://localhost:3000/login");
+      // Create product page should not be accessible to unathenticated users
+      await page.goto("http://localhost:3000/dashboard/admin/create-product", {
+        waitUntil: "domcontentloaded",
+      });
+      await expect(page).toHaveURL("http://localhost:3000/login");
+      // Admin products page should not be accessible to unauthenticated users
+      await page.goto("http://localhost:3000/dashboard/admin/products", {
+        waitUntil: "domcontentloaded",
+      });
+      await expect(page).toHaveURL("http://localhost:3000/login");
+      //Admin orders page should not be accessible to uauthenticated users
+      await page.goto("http://localhost:3000/dashboard/admin/orders", {
+        waitUntil: "domcontentloaded",
+      });
+      await expect(page).toHaveURL("http://localhost:3000/login");
+    });
+  });
+});

--- a/ui-tests/unauthorisedAdminAccess.spec.js
+++ b/ui-tests/unauthorisedAdminAccess.spec.js
@@ -78,7 +78,7 @@ test.describe("Unauthorised access to admin features", () => {
       // Navigating to login page
       await page.getByRole("link", { name: "Login" }).click();
 
-      // Keying in correct email address but wrong password
+      // Login as a non-admin user
       await page
         .getByRole("textbox", { name: "Enter Your Email" })
         .fill("notadmin@mail.com");
@@ -116,33 +116,53 @@ test.describe("Unauthorised access to admin features", () => {
       );
     });
 
-    // TODO: Might change to redirecting to forbidden page instead since user is technically logged in
-    test("should redirect to login page", async ({ page }) => {
-      // Admin dashboard should not be accessible to unauthenticated users
+    // Non-admin users redirected to forbidden page instead since user is technically logged in
+    test("should redirect to forbidden page", async ({ page }) => {
+      // Navigating to login page
+      await page.getByRole("link", { name: "Login" }).click();
+      // Login as a non-admin user
+      await page
+        .getByRole("textbox", { name: "Enter Your Email" })
+        .fill("notadmin@mail.com");
+      await page
+        .getByRole("textbox", { name: "Enter Your Password" })
+        .fill("cs4218");
+      await page.getByRole("button", { name: "Login" }).click();
+
+      // Wait for login to complete by checking for name
+      await expect(
+        page.getByRole("button", { name: "Test User" })
+      ).toBeVisible();
+
+      // Admin dashboard should not be accessible to non-admin signed in users
       await page.goto("http://localhost:3000/dashboard/admin", {
-        waitUntil: "domcontentloaded",
+        waitUntil: "networkidle",
       });
-      await expect(page).toHaveURL("http://localhost:3000/login");
-      // Create category page should not be accessible to unauthenticated users
+      await expect(page).toHaveURL("http://localhost:3000/forbidden");
+
+      // Create category page should not be accessible to non-admin signed in users
       await page.goto("http://localhost:3000/dashboard/admin/create-category", {
-        waitUntil: "domcontentloaded",
+        waitUntil: "networkidle",
       });
-      await expect(page).toHaveURL("http://localhost:3000/login");
-      // Create product page should not be accessible to unathenticated users
+      await expect(page).toHaveURL("http://localhost:3000/forbidden");
+
+      // Create product page should not be accessible to non-admin signed in users
       await page.goto("http://localhost:3000/dashboard/admin/create-product", {
-        waitUntil: "domcontentloaded",
+        waitUntil: "networkidle",
       });
-      await expect(page).toHaveURL("http://localhost:3000/login");
-      // Admin products page should not be accessible to unauthenticated users
+      await expect(page).toHaveURL("http://localhost:3000/forbidden");
+
+      // Admin products page should not be accessible to non-admin signed in users
       await page.goto("http://localhost:3000/dashboard/admin/products", {
-        waitUntil: "domcontentloaded",
+        waitUntil: "networkidle",
       });
-      await expect(page).toHaveURL("http://localhost:3000/login");
-      //Admin orders page should not be accessible to uauthenticated users
+      await expect(page).toHaveURL("http://localhost:3000/forbidden");
+
+      //Admin orders page should not be accessible to non-admin signed in users
       await page.goto("http://localhost:3000/dashboard/admin/orders", {
-        waitUntil: "domcontentloaded",
+        waitUntil: "networkidle",
       });
-      await expect(page).toHaveURL("http://localhost:3000/login");
+      await expect(page).toHaveURL("http://localhost:3000/forbidden");
     });
   });
 });


### PR DESCRIPTION
This PR includes UI test cases for unauthorised access attempts to admin pages, and an overhaul on token management and authorization by AdminRoute.js to ensure a more intuitive unauthorised access routing.

## USER FLOW TESTED:
Homepage (unauthenticated/normal user) -> Any Admin Page -> Forbidden Page

## UI Testing Done:
* Redirecting uauthenticated users to login page when trying to access admin pages
* Redirecting signed-in, non-admin users to forbidden page when trying to access admin pages
* Validation that UI for non-admin users only contain non-admin features

## Bug Fix/ Improved Feature:
* AdminRoute tries to validate auth context first, otherwise checks in localStorage for auth token. It therefore allows unauthenticated to be redirected to login and non-admin signed in users to be redirected into forbidden page
* Better error handling (network error), redirects still defaults to login page if these general errors are encountered


## Note:
This PR focuses only on **Unauthorised access prevention** and does not take care of **Authorised accessibility into admin pages** UI test cases: