### PR TITLE
Test/admin delete product UI tests

### DIFF
--- a/client/src/pages/admin/CreateProduct.test.js
+++ b/client/src/pages/admin/CreateProduct.test.js
@@ -1,7 +1,7 @@
 // CreateProduct.test.js
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { act } from "react";
+import { act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import CreateProduct from "./CreateProduct";

--- a/client/src/pages/admin/CreateProduct.test.js
+++ b/client/src/pages/admin/CreateProduct.test.js
@@ -1,7 +1,7 @@
 // CreateProduct.test.js
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import CreateProduct from "./CreateProduct";

--- a/client/src/pages/admin/Products.js
+++ b/client/src/pages/admin/Products.js
@@ -14,7 +14,7 @@ const Products = () => {
       setProducts(data.products);
     } catch (error) {
       console.log(error);
-      toast.error("Someething Went Wrong");
+      toast.error("Something Went Wrong");
     }
   };
 

--- a/client/src/pages/admin/Products.test.js
+++ b/client/src/pages/admin/Products.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { act } from "react-dom/test-utils";
 import { MemoryRouter } from "react-router-dom";
-import '@testing-library/jest-dom'; // I have no idea what this is, but it works
+import "@testing-library/jest-dom"; // I have no idea what this is, but it works
 import Products from "./Products";
 import axios from "axios";
 import toast from "react-hot-toast";
@@ -94,7 +94,7 @@ describe("Products Component", () => {
       );
     });
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Someething Went Wrong");
+      expect(toast.error).toHaveBeenCalledWith("Something Went Wrong");
     });
   });
 

--- a/client/src/pages/admin/UpdateProduct.js
+++ b/client/src/pages/admin/UpdateProduct.js
@@ -30,7 +30,6 @@ const UpdateProduct = () => {
       setId(data.product._id);
       setDescription(data.product.description);
       setPrice(data.product.price);
-      setPrice(data.product.price);
       setQuantity(data.product.quantity);
       setShipping(data.product.shipping);
       setCategory(data.product.category._id);
@@ -51,7 +50,7 @@ const UpdateProduct = () => {
       }
     } catch (error) {
       console.log(error);
-      toast.error("Something wwent wrong in getting catgeory");
+      toast.error("Something went wrong in getting category");
     }
   };
 
@@ -70,7 +69,7 @@ const UpdateProduct = () => {
       productData.append("quantity", quantity);
       photo && productData.append("photo", photo);
       productData.append("category", category);
-      productData.append('shipping', shipping);
+      productData.append("shipping", shipping);
       const { data } = await axios.put(
         `/api/v1/product/update-product/${id}`,
         productData
@@ -90,15 +89,45 @@ const UpdateProduct = () => {
   //delete a product
   const handleDelete = async () => {
     try {
-      let answer = window.prompt("Are You Sure want to delete this product ? ");
-      if (!answer) return;
-      const { data } = await axios.delete(
-        `/api/v1/product/delete-product/${id}`
+      let answer = window.prompt(
+        "Are You Sure want to delete this product ? Type 'yes' to confirm"
       );
-      toast.success("Product DEleted Succfully");
+      if (!answer || answer.toLowerCase() !== "yes") {
+        return;
+      }
+      if (!id) {
+        toast.error("Cannot delete product: ID is missing");
+        return;
+      }
+
+      // Get the product ID directly if it's not already set
+      if (!id && params.slug) {
+        try {
+          const { data } = await axios.get(
+            `/api/v1/product/get-product/${params.slug}`
+          );
+          if (data?.product?._id) {
+            setId(data.product._id);
+          }
+        } catch (fetchError) {
+          console.error("Error fetching product ID:", fetchError);
+          toast.error("Cannot delete product: failed to fetch ID");
+        }
+      }
+
+      // Double-check we have an ID before proceeding
+      if (!id) {
+        toast.error("Cannot delete: Product ID still missing after retry");
+        return;
+      }
+
+      const deleteUrl = `/api/v1/product/delete-product/${id}`;
+
+      const { data } = await axios.delete(deleteUrl);
+      toast.success("Product Deleted Successfully");
       navigate("/dashboard/admin/products");
     } catch (error) {
-      console.log(error);
+      console.log("Delete error:", error);
       toast.error("Something went wrong");
     }
   };
@@ -220,9 +249,11 @@ const UpdateProduct = () => {
                 </button>
               </div>
               <div className="mb-3">
-                <button className="btn btn-danger" onClick={handleDelete}>
-                  DELETE PRODUCT
-                </button>
+                {id && (
+                  <button className="btn btn-danger" onClick={handleDelete}>
+                    DELETE PRODUCT
+                  </button>
+                )}
               </div>
             </div>
           </div>

--- a/client/src/pages/admin/UpdateProduct.test.js
+++ b/client/src/pages/admin/UpdateProduct.test.js
@@ -42,13 +42,13 @@ describe("UpdateProduct Component", () => {
     shipping: false,
     category: {
       _id: "1",
-      name: "Test Category"
-    }
+      name: "Test Category",
+    },
   };
 
   const mockCategories = [
     { _id: "1", name: "Test Category" },
-    { _id: "2", name: "Another Category" }
+    { _id: "2", name: "Another Category" },
   ];
 
   beforeEach(() => {
@@ -58,22 +58,22 @@ describe("UpdateProduct Component", () => {
     axios.get.mockImplementation((url) => {
       if (url.includes("/api/v1/product/get-product/")) {
         return Promise.resolve({
-          data: { success: true, product: mockProduct }
+          data: { success: true, product: mockProduct },
         });
       } else if (url.includes("/api/v1/category/get-category")) {
         return Promise.resolve({
-          data: { success: true, category: mockCategories }
+          data: { success: true, category: mockCategories },
         });
       }
       return Promise.reject(new Error("Not found"));
     });
 
     axios.put.mockResolvedValue({
-      data: { success: true }
+      data: { success: true },
     });
 
     axios.delete.mockResolvedValue({
-      data: { success: true }
+      data: { success: true },
     });
   });
 
@@ -148,8 +148,10 @@ describe("UpdateProduct Component", () => {
 
     // Check that prompt was shown
     expect(window.prompt).toHaveBeenCalled();
-    expect(axios.delete).toHaveBeenCalledWith("/api/v1/product/delete-product/123");
-    expect(toast.success).toHaveBeenCalledWith("Product DEleted Succfully");
+    expect(axios.delete).toHaveBeenCalledWith(
+      "/api/v1/product/delete-product/123"
+    );
+    expect(toast.success).toHaveBeenCalledWith("Product Deleted Successfully");
     expect(mockedNavigate).toHaveBeenCalledWith("/dashboard/admin/products");
   });
 
@@ -185,10 +187,12 @@ describe("UpdateProduct Component", () => {
 
     // Create a file and trigger upload
     const file = new File(["dummy content"], "test.png", { type: "image/png" });
-    
+
     // Find the file input (it's hidden, so we need to find its parent label first)
-    const fileInput = screen.getByLabelText(/Upload Photo/i, { selector: 'input' });
-    
+    const fileInput = screen.getByLabelText(/Upload Photo/i, {
+      selector: "input",
+    });
+
     // Trigger file upload
     await act(async () => {
       fireEvent.change(fileInput, { target: { files: [file] } });

--- a/client/src/pages/admin/__snapshots__/CreateProduct.test.js.snap
+++ b/client/src/pages/admin/__snapshots__/CreateProduct.test.js.snap
@@ -31,36 +31,32 @@ exports[`CreateProduct Component Snapshot matches snapshot 1`] = `
             class="m-1 w-75"
           >
             <div
-              class="ant-select ant-select-lg form-select mb-3 css-dev-only-do-not-override-tjsggz ant-select-single ant-select-show-arrow ant-select-show-search"
+              class="ant-select ant-select-lg form-select mb-3 css-dev-only-do-not-override-1drr2mu ant-select-single ant-select-show-arrow ant-select-show-search"
             >
               <div
                 class="ant-select-selector"
               >
                 <span
-                  class="ant-select-selection-wrap"
+                  class="ant-select-selection-search"
                 >
-                  <span
-                    class="ant-select-selection-search"
-                  >
-                    <input
-                      aria-autocomplete="list"
-                      aria-controls="rc_select_TEST_OR_SSR_list"
-                      aria-expanded="false"
-                      aria-haspopup="listbox"
-                      aria-owns="rc_select_TEST_OR_SSR_list"
-                      autocomplete="off"
-                      class="ant-select-selection-search-input"
-                      id="rc_select_TEST_OR_SSR"
-                      role="combobox"
-                      type="search"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="ant-select-selection-placeholder"
-                  >
-                    Select a Category
-                  </span>
+                  <input
+                    aria-autocomplete="list"
+                    aria-controls="rc_select_TEST_OR_SSR_list"
+                    aria-expanded="false"
+                    aria-haspopup="listbox"
+                    aria-owns="rc_select_TEST_OR_SSR_list"
+                    autocomplete="off"
+                    class="ant-select-selection-search-input"
+                    id="rc_select_TEST_OR_SSR"
+                    role="combobox"
+                    type="search"
+                    value=""
+                  />
+                </span>
+                <span
+                  class="ant-select-selection-placeholder"
+                >
+                  Select a Category
                 </span>
               </div>
               <span
@@ -151,36 +147,32 @@ exports[`CreateProduct Component Snapshot matches snapshot 1`] = `
               class="mb-3"
             >
               <div
-                class="ant-select ant-select-lg form-select mb-3 css-dev-only-do-not-override-tjsggz ant-select-single ant-select-show-arrow ant-select-show-search"
+                class="ant-select ant-select-lg form-select mb-3 css-dev-only-do-not-override-1drr2mu ant-select-single ant-select-show-arrow ant-select-show-search"
               >
                 <div
                   class="ant-select-selector"
                 >
                   <span
-                    class="ant-select-selection-wrap"
+                    class="ant-select-selection-search"
                   >
-                    <span
-                      class="ant-select-selection-search"
-                    >
-                      <input
-                        aria-autocomplete="list"
-                        aria-controls="rc_select_TEST_OR_SSR_list"
-                        aria-expanded="false"
-                        aria-haspopup="listbox"
-                        aria-owns="rc_select_TEST_OR_SSR_list"
-                        autocomplete="off"
-                        class="ant-select-selection-search-input"
-                        id="rc_select_TEST_OR_SSR"
-                        role="combobox"
-                        type="search"
-                        value=""
-                      />
-                    </span>
-                    <span
-                      class="ant-select-selection-placeholder"
-                    >
-                      Select Shipping
-                    </span>
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="rc_select_TEST_OR_SSR_list"
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      aria-owns="rc_select_TEST_OR_SSR_list"
+                      autocomplete="off"
+                      class="ant-select-selection-search-input"
+                      id="rc_select_TEST_OR_SSR"
+                      role="combobox"
+                      type="search"
+                      value=""
+                    />
+                  </span>
+                  <span
+                    class="ant-select-selection-placeholder"
+                  >
+                    Select Shipping
                   </span>
                 </div>
                 <span

--- a/client/src/pages/admin/__snapshots__/CreateProduct.test.js.snap
+++ b/client/src/pages/admin/__snapshots__/CreateProduct.test.js.snap
@@ -31,32 +31,36 @@ exports[`CreateProduct Component Snapshot matches snapshot 1`] = `
             class="m-1 w-75"
           >
             <div
-              class="ant-select ant-select-lg form-select mb-3 css-dev-only-do-not-override-1drr2mu ant-select-single ant-select-show-arrow ant-select-show-search"
+              class="ant-select ant-select-lg form-select mb-3 css-dev-only-do-not-override-tjsggz ant-select-single ant-select-show-arrow ant-select-show-search"
             >
               <div
                 class="ant-select-selector"
               >
                 <span
-                  class="ant-select-selection-search"
+                  class="ant-select-selection-wrap"
                 >
-                  <input
-                    aria-autocomplete="list"
-                    aria-controls="rc_select_TEST_OR_SSR_list"
-                    aria-expanded="false"
-                    aria-haspopup="listbox"
-                    aria-owns="rc_select_TEST_OR_SSR_list"
-                    autocomplete="off"
-                    class="ant-select-selection-search-input"
-                    id="rc_select_TEST_OR_SSR"
-                    role="combobox"
-                    type="search"
-                    value=""
-                  />
-                </span>
-                <span
-                  class="ant-select-selection-placeholder"
-                >
-                  Select a Category
+                  <span
+                    class="ant-select-selection-search"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-controls="rc_select_TEST_OR_SSR_list"
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      aria-owns="rc_select_TEST_OR_SSR_list"
+                      autocomplete="off"
+                      class="ant-select-selection-search-input"
+                      id="rc_select_TEST_OR_SSR"
+                      role="combobox"
+                      type="search"
+                      value=""
+                    />
+                  </span>
+                  <span
+                    class="ant-select-selection-placeholder"
+                  >
+                    Select a Category
+                  </span>
                 </span>
               </div>
               <span
@@ -147,32 +151,36 @@ exports[`CreateProduct Component Snapshot matches snapshot 1`] = `
               class="mb-3"
             >
               <div
-                class="ant-select ant-select-lg form-select mb-3 css-dev-only-do-not-override-1drr2mu ant-select-single ant-select-show-arrow ant-select-show-search"
+                class="ant-select ant-select-lg form-select mb-3 css-dev-only-do-not-override-tjsggz ant-select-single ant-select-show-arrow ant-select-show-search"
               >
                 <div
                   class="ant-select-selector"
                 >
                   <span
-                    class="ant-select-selection-search"
+                    class="ant-select-selection-wrap"
                   >
-                    <input
-                      aria-autocomplete="list"
-                      aria-controls="rc_select_TEST_OR_SSR_list"
-                      aria-expanded="false"
-                      aria-haspopup="listbox"
-                      aria-owns="rc_select_TEST_OR_SSR_list"
-                      autocomplete="off"
-                      class="ant-select-selection-search-input"
-                      id="rc_select_TEST_OR_SSR"
-                      role="combobox"
-                      type="search"
-                      value=""
-                    />
-                  </span>
-                  <span
-                    class="ant-select-selection-placeholder"
-                  >
-                    Select Shipping
+                    <span
+                      class="ant-select-selection-search"
+                    >
+                      <input
+                        aria-autocomplete="list"
+                        aria-controls="rc_select_TEST_OR_SSR_list"
+                        aria-expanded="false"
+                        aria-haspopup="listbox"
+                        aria-owns="rc_select_TEST_OR_SSR_list"
+                        autocomplete="off"
+                        class="ant-select-selection-search-input"
+                        id="rc_select_TEST_OR_SSR"
+                        role="combobox"
+                        type="search"
+                        value=""
+                      />
+                    </span>
+                    <span
+                      class="ant-select-selection-placeholder"
+                    >
+                      Select Shipping
+                    </span>
                   </span>
                 </div>
                 <span

--- a/ui-tests/adminDeleteProduct.spec.js
+++ b/ui-tests/adminDeleteProduct.spec.js
@@ -122,7 +122,7 @@ test.describe("Admin Delete Product", () => {
       page.locator('.card-body:has-text("Test Product 2")')
     ).toBeVisible();
 
-    // Navigate to Product detail
+    // Navigate to Product detail for cancellation of delete test
     await page.getByRole("button", { name: "deleteproductadmin" }).click();
     await page.getByRole("link", { name: "Dashboard" }).click();
     await page.getByRole("link", { name: "Products" }).click();
@@ -159,7 +159,7 @@ test.describe("Admin Delete Product", () => {
       page.locator('.card-body:has-text("Test Product 2")')
     ).toBeVisible();
 
-    // Navigate to Product detail
+    // Navigate to Product detail that is to be deleted
     await page.getByRole("button", { name: "deleteproductadmin" }).click();
     await page.getByRole("link", { name: "Dashboard" }).click();
     await page.getByRole("link", { name: "Products" }).click();

--- a/ui-tests/adminDeleteProduct.spec.js
+++ b/ui-tests/adminDeleteProduct.spec.js
@@ -45,6 +45,16 @@ test.beforeEach(async ({ page }) => {
     price: 20,
   });
   await page.goto("http://localhost:3000", { waitUntil: "commit" });
+
+  await page.getByRole("link", { name: "Login" }).click();
+
+  await page
+    .getByRole("textbox", { name: "Enter Your Email" })
+    .fill("deleteproductadmin@mail.com");
+  await page
+    .getByRole("textbox", { name: "Enter Your Password" })
+    .fill("cs4218@test.com");
+  await page.getByRole("button", { name: "LOGIN" }).click();
 });
 
 test.afterEach(async () => {
@@ -59,17 +69,6 @@ test.describe("Admin Delete Product", () => {
   test("should allow admin to delete products from the database", async ({
     page,
   }) => {
-    //TODO: Might want to change this to beforeEach
-    await page.getByRole("link", { name: "Login" }).click();
-
-    await page
-      .getByRole("textbox", { name: "Enter Your Email" })
-      .fill("deleteproductadmin@mail.com");
-    await page
-      .getByRole("textbox", { name: "Enter Your Password" })
-      .fill("cs4218@test.com");
-    await page.getByRole("button", { name: "LOGIN" }).click();
-
     // Check both items are visible
     await expect(
       page.locator('.card-body:has-text("Test Product 1")')
@@ -83,21 +82,21 @@ test.describe("Admin Delete Product", () => {
     await page.getByRole("link", { name: "Dashboard" }).click();
     await page.getByRole("link", { name: "Products" }).click();
     await page.getByRole("link", { name: "Test Product 1" }).click();
-    // await page.waitForSelector('text=Update Product');
+
+    // Handle dialog confirmation for when we click DELET PRODUCT
     page.once("dialog", (dialog) => {
       console.log(`Dialog message: ${dialog.message()}`);
       dialog.accept("yes").catch(() => {});
     });
     await page.getByRole("button", { name: "DELETE PRODUCT" }).click();
-
-    await page.getByText("HOME");
-
     await page.waitForResponse((response) => {
       if (response.status() === 200) {
         return true;
       }
     });
-    await page.waitForTimeout(2000);
+
+    // Navigate back HOME
+    await page.getByText("HOME").click();
 
     await expect(
       page.locator('.card-body:has-text("Test Product 2")')
@@ -107,4 +106,12 @@ test.describe("Admin Delete Product", () => {
       page.locator('.card-body:has-text("Test Product 1")')
     ).not.toBeVisible({ timeout: 10000 });
   });
+
+  test("should redirect to 'all products list' page after delete", async ({
+    page,
+  }) => {});
+
+  test("should not delete product when dialog is not accepted with a 'yes'", async ({
+    page,
+  }) => {});
 });

--- a/ui-tests/adminDeleteProduct.spec.js
+++ b/ui-tests/adminDeleteProduct.spec.js
@@ -1,0 +1,110 @@
+import { test, expect } from "@playwright/test";
+import dotenv from "dotenv";
+import mongoose from "mongoose";
+import userModel from "../models/userModel";
+import productModel from "../models/productModel";
+import { ObjectId } from "mongodb";
+
+dotenv.config();
+
+test.beforeEach(async ({ page }) => {
+  await mongoose.connect(process.env.MONGO_URL);
+
+  const hashedPassword =
+    "$2b$10$//wWsN./fEX1WiipH57HG.SAwgkYv1MRrPSkpXM38Dy5seOEhCoUy";
+
+  await new userModel({
+    name: "deleteproductadmin",
+    email: "deleteproductadmin@mail.com",
+    password: hashedPassword,
+    role: 1,
+    address: "123 Test Road",
+    phone: "81234567",
+    answer: "password is cs4218@test.com",
+  }).save();
+
+  const categoryId = new ObjectId("bc7f29ed898fefd6a5f713fd");
+
+  await productModel.create({
+    name: "Test Product 1",
+    slug: "test-product-1",
+    description: "Test Product 1 description",
+    quantity: "10",
+    shipping: "1",
+    category: categoryId,
+    price: 10,
+  });
+
+  await productModel.create({
+    name: "Test Product 2",
+    slug: "test-product-2",
+    description: "Test Product 2 description",
+    quantity: "5",
+    shipping: "0",
+    category: categoryId,
+    price: 20,
+  });
+  await page.goto("http://localhost:3000", { waitUntil: "commit" });
+});
+
+test.afterEach(async () => {
+  await userModel.deleteMany({ email: "deleteproductadmin@mail.com" });
+  await productModel.deleteMany({ name: "Test Product 1" });
+
+  await productModel.deleteMany({ name: "Test Product 2" });
+  await mongoose.disconnect();
+});
+
+test.describe("Admin Delete Product", () => {
+  test("should allow admin to delete products from the database", async ({
+    page,
+  }) => {
+    //TODO: Might want to change this to beforeEach
+    await page.getByRole("link", { name: "Login" }).click();
+
+    await page
+      .getByRole("textbox", { name: "Enter Your Email" })
+      .fill("deleteproductadmin@mail.com");
+    await page
+      .getByRole("textbox", { name: "Enter Your Password" })
+      .fill("cs4218@test.com");
+    await page.getByRole("button", { name: "LOGIN" }).click();
+
+    // Check both items are visible
+    await expect(
+      page.locator('.card-body:has-text("Test Product 1")')
+    ).toBeVisible();
+
+    await expect(
+      page.locator('.card-body:has-text("Test Product 2")')
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "deleteproductadmin" }).click();
+    await page.getByRole("link", { name: "Dashboard" }).click();
+    await page.getByRole("link", { name: "Products" }).click();
+    await page.getByRole("link", { name: "Test Product 1" }).click();
+    // await page.waitForSelector('text=Update Product');
+    page.once("dialog", (dialog) => {
+      console.log(`Dialog message: ${dialog.message()}`);
+      dialog.accept("yes").catch(() => {});
+    });
+    await page.getByRole("button", { name: "DELETE PRODUCT" }).click();
+
+    await page.getByText("HOME");
+
+    await page.waitForResponse((response) => {
+      if (response.status() === 200) {
+        return true;
+      }
+    });
+    await page.waitForTimeout(2000);
+
+    await expect(
+      page.locator('.card-body:has-text("Test Product 2")')
+    ).toBeVisible({ timeout: 10000 });
+
+    await expect(
+      page.locator('.card-body:has-text("Test Product 1")')
+    ).not.toBeVisible({ timeout: 10000 });
+  });
+});


### PR DESCRIPTION
This PR includes UI test cases for admin deletion of products workflow via the admin dashboard to ensure that deletion of products are handled gracefully and UI renders only products that are intended to remain on the platform (should exclude the deleted product). This PR also contains bug fixes and improvements on Products.js and UpdateProduct.js

## USER FLOW TESTED:

Homepage (authenticated admin user) ->  click on profile name on navbar (homepage) -> click on “dashboard” on navbar (homepage) -> click on “products” (admin dashboard) -> click on product to delete (admin dashboard) -> click “delete product” (admin dashboard) -> product successfully deleted-> click “home” on navbar (admin dashboard) -> check for deleted product (homepage) -> product not found

## UI Testing Done:
* Admin ability to delete product successfully
* Re-direction to `/dashboard/admin/products` URL after confirmation of deletion
* Cancellation of deletion should not delete the product from the platform

## Bug Fixes:
* Minor typo in Products.js
* Remove duplicate line in UpdateProduct.js
* Better Dialog for more precise instruction to admin
* Conditional rendering for the Delete Button so as to prevent race condition (component has not set id yet may cause deletion to have no id sent to database leading to error)