### PR TITLE
Fix bug with regards to loadmore and filter

### DIFF
--- a/client/src/pages/HomePage.js
+++ b/client/src/pages/HomePage.js
@@ -62,7 +62,8 @@ const HomePage = () => {
       const { data } = await axios.get("/api/v1/product/product-count", {
         params: filtersApplied,
       });
-      if (data.total) {
+      // Check for null and undefined values for total
+      if (data.total !== null && data.total !== undefined) {
         setTotal(data.total);
       }
     } catch (error) {
@@ -134,7 +135,10 @@ const HomePage = () => {
   }, [checked, radio]);
 
   useEffect(() => {
-    if (checked.length || radio.length) filterProduct();
+    if (checked.length || radio.length) {
+      filterProduct();
+      setPage(1);
+    }
   }, [checked, radio]);
 
   useEffect(() => {


### PR DESCRIPTION
**Bug 1**: Homepage view products -> click some category checkbox -> click loadMore -> click filter radio -> click Loadmore -> clicking loadmore does not show more filter products (expected behaviour is to show more filtered products)

**Root cause analysis**: Page was not reset to page 1 whenever a new radio/checkbox is clicked, but continues to increment

**Bug 2**: LoadMore button is shown with no products when a user clicks a filter radio (price bracket) that does not correspond to any product price. In other words, expected behaviour is an empty screen with no loadmore button, but in this case the loadmore button exists

**Root cause analysis:** In  getTotal method that updates the total product count, there was a check that does checks if (data.total). If data.total was 0, this would be a falsy value even though the value 0 may have been valid.